### PR TITLE
[codex] add music generator promo banner

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import './globals.css'
 import Script from 'next/script'
+import PromoBanner from '@/components/promo-banner'
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://playbackstats.com'),
@@ -26,6 +27,7 @@ export default function RootLayout({
         </Script>
       </head>
       <body>
+        <PromoBanner />
         {children}
       </body>
     </html>

--- a/components/promo-banner.tsx
+++ b/components/promo-banner.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link"
+import { ArrowUpRight, Music2 } from "lucide-react"
+
+const MUSIC_GENERATOR_URL = "https://music-generator.net/"
+
+export default function PromoBanner() {
+  return (
+    <div className="w-full border-b border-cyan-400/20 bg-zinc-950 text-white">
+      <Link
+        href={MUSIC_GENERATOR_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="group mx-auto flex min-h-12 max-w-7xl flex-wrap items-center justify-center gap-x-2 gap-y-1 px-4 py-2 text-center text-sm transition-colors hover:bg-white/[0.04] sm:min-h-10 sm:gap-x-3 sm:text-left"
+        aria-label="Create AI music and background tracks with Musefy"
+      >
+        <span className="inline-flex items-center gap-1.5 font-semibold text-cyan-200">
+          <Music2 className="h-4 w-4" aria-hidden="true" />
+          AI music for creators
+        </span>
+        <span className="text-zinc-200 sm:hidden">
+          Create BGM for your next video.
+        </span>
+        <span className="hidden text-zinc-200 sm:inline">
+          Generate songs, BGM, and lyrics for videos, streams, and podcasts.
+        </span>
+        <span className="inline-flex items-center gap-1 font-semibold text-white underline-offset-4 group-hover:underline">
+          Try Musefy
+          <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+        </span>
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add a reusable top-of-page promo banner linking to https://music-generator.net/.
- Mount the banner from the root layout so it appears across the site.
- Use compact mobile copy to keep the YouTube History Visualizer hero visible.

## Impact
This gives the site a lightweight cross-promo entry point for creators who may need AI-generated music, BGM, and lyrics for video workflows.

## Validation
- `eslint .` passed with 0 errors and 25 pre-existing warnings.
- `tsc --noEmit` passed.
- `next build` passed.
- Browser QA on `localhost:3000`: desktop banner height 40px, mobile banner height 60px, no horizontal overflow, no console errors.
