### PR TITLE
Add Spotify history analytics and unify Playback Stats UI

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -1,16 +1,17 @@
 import { Metadata } from "next"
 
 export const metadata: Metadata = {
-  title: "Dashboard | YouTube History Visualizer",
-  description: "View insights and analytics from your YouTube watch history data.",
+  title: "YouTube Dashboard | Playback Stats",
+  description: "Explore private insights and charts generated from your local YouTube watch history export.",
   openGraph: {
-    title: "Dashboard | YouTube History Visualizer",
-    description: "View insights and analytics from your YouTube watch history data.",
+    title: "YouTube Dashboard | Playback Stats",
+    description: "Explore private insights and charts generated from your local YouTube watch history export.",
     url: "https://playbackstats.com/dashboard",
+    siteName: "Playback Stats",
   },
   twitter: {
-    title: "Dashboard | YouTube History Visualizer",
-    description: "View insights and analytics from your YouTube watch history data.",
+    title: "YouTube Dashboard | Playback Stats",
+    description: "Explore private insights and charts generated from your local YouTube watch history export.",
   },
   alternates: {
     canonical: "https://playbackstats.com/dashboard",
@@ -23,4 +24,4 @@ export default function DashboardLayout({
   children: React.ReactNode
 }) {
   return <>{children}</>;
-} 
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -13,8 +13,9 @@ export const metadata: Metadata = {
     title: "YouTube Dashboard | Playback Stats",
     description: "Explore private insights and charts generated from your local YouTube watch history export.",
   },
-  alternates: {
-    canonical: "https://playbackstats.com/dashboard",
+  robots: {
+    index: false,
+    follow: false,
   },
 }
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -17,6 +17,8 @@ import DonationBanner from "@/components/dashboard/donation-banner"
 import PersonalityInsights from "@/components/dashboard/personality-insights"
 import FunFacts from "@/components/dashboard/fun-facts"
 import Achievements from "@/components/dashboard/achievements"
+import PlaybackFooter from "@/components/playback-footer"
+import PlaybackHeader from "@/components/playback-header"
 
 // Define interfaces for the processed data
 interface Stats {
@@ -61,33 +63,37 @@ export default function DashboardPage() {
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    // Load the processed data from sessionStorage
-    try {
-      const statsJson = sessionStorage.getItem("youtubeHistoryStats")
-      const dailyViewsJson = sessionStorage.getItem("youtubeHistoryDailyViews")
-      const hourlyViewsJson = sessionStorage.getItem("youtubeHistoryHourlyViews")
-      const topVideosJson = sessionStorage.getItem("youtubeHistoryTopVideos")
-      const channelsJson = sessionStorage.getItem("youtubeHistoryChannels")
-      const advancedStatsJson = sessionStorage.getItem("youtubeHistoryAdvancedStats")
+    const frameId = window.requestAnimationFrame(() => {
+      // Load the processed data from sessionStorage after the first paint.
+      try {
+        const statsJson = sessionStorage.getItem("youtubeHistoryStats")
+        const dailyViewsJson = sessionStorage.getItem("youtubeHistoryDailyViews")
+        const hourlyViewsJson = sessionStorage.getItem("youtubeHistoryHourlyViews")
+        const topVideosJson = sessionStorage.getItem("youtubeHistoryTopVideos")
+        const channelsJson = sessionStorage.getItem("youtubeHistoryChannels")
+        const advancedStatsJson = sessionStorage.getItem("youtubeHistoryAdvancedStats")
 
-      if (!statsJson) {
-        setError("No data found. Please upload your YouTube history file.")
+        if (!statsJson) {
+          setError("No data found. Please upload your YouTube history file.")
+          setIsLoading(false)
+          return
+        }
+
+        setStats(JSON.parse(statsJson))
+        setDailyViews(dailyViewsJson ? JSON.parse(dailyViewsJson) : [])
+        setHourlyViews(hourlyViewsJson ? JSON.parse(hourlyViewsJson) : [])
+        setTopVideos(topVideosJson ? JSON.parse(topVideosJson) : [])
+        setChannelCounts(channelsJson ? JSON.parse(channelsJson) : [])
+        setAdvancedStats(advancedStatsJson ? JSON.parse(advancedStatsJson) : null)
         setIsLoading(false)
-        return
+      } catch (err) {
+        console.error("Error loading data:", err)
+        setError("Failed to load the processed data. Please try uploading your file again.")
+        setIsLoading(false)
       }
+    })
 
-      setStats(JSON.parse(statsJson))
-      setDailyViews(dailyViewsJson ? JSON.parse(dailyViewsJson) : [])
-      setHourlyViews(hourlyViewsJson ? JSON.parse(hourlyViewsJson) : [])
-      setTopVideos(topVideosJson ? JSON.parse(topVideosJson) : [])
-      setChannelCounts(channelsJson ? JSON.parse(channelsJson) : [])
-      setAdvancedStats(advancedStatsJson ? JSON.parse(advancedStatsJson) : null)
-      setIsLoading(false)
-    } catch (err) {
-      console.error("Error loading data:", err)
-      setError("Failed to load the processed data. Please try uploading your file again.")
-      setIsLoading(false)
-    }
+    return () => window.cancelAnimationFrame(frameId)
   }, [])
 
   const handleBackToHome = () => {
@@ -96,76 +102,77 @@ export default function DashboardPage() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center min-h-screen gradient-bg">
-        <div className="text-center space-y-6 animate-fade-in">
-          <div className="relative">
-            <div className="w-20 h-20 rounded-full border-4 border-muted mx-auto" />
-            <div className="absolute inset-0 w-20 h-20 rounded-full border-4 border-primary border-t-transparent mx-auto animate-spin" />
+      <div className="dark flex min-h-screen flex-col bg-zinc-950 text-white">
+        <PlaybackHeader activePlatform="youtube" />
+        <main id="main-content" className="flex flex-1 items-center justify-center px-4 py-16">
+          <div className="w-full max-w-md space-y-6 animate-fade-in" aria-live="polite">
+            <div className="flex items-center gap-3">
+              <div className="h-10 w-10 animate-pulse rounded-xl bg-red-500/15" />
+              <div className="flex-1 space-y-2">
+                <div className="h-3 w-40 animate-pulse rounded-full bg-white/10" />
+                <div className="h-2 w-56 animate-pulse rounded-full bg-white/[0.06]" />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="h-28 animate-pulse rounded-2xl bg-white/[0.05]" />
+              <div className="h-28 animate-pulse rounded-2xl bg-white/[0.05]" />
+            </div>
+            <div className="h-48 animate-pulse rounded-3xl bg-white/[0.04]" />
+            <div className="text-center">
+              <p className="text-sm font-medium text-white">Preparing your viewing insights</p>
+              <p className="mt-1 text-xs text-zinc-500">Loading the compact dashboard data from this session</p>
+            </div>
           </div>
-          <div className="space-y-2">
-            <p className="text-xl font-semibold">Loading your insights...</p>
-            <p className="text-sm text-muted-foreground">Preparing your YouTube history dashboard</p>
-          </div>
-        </div>
+        </main>
+        <PlaybackFooter />
       </div>
     )
   }
 
   if (error || !stats) {
     return (
-      <div className="flex items-center justify-center min-h-screen gradient-bg">
-        <div className="text-center max-w-md mx-auto p-8 animate-scale-in">
-          <div className="w-20 h-20 mx-auto mb-6 rounded-2xl bg-destructive/10 flex items-center justify-center">
-            <span className="text-4xl">😕</span>
+      <div className="dark flex min-h-screen flex-col bg-zinc-950 text-white">
+        <PlaybackHeader activePlatform="youtube" />
+        <main id="main-content" className="flex flex-1 items-center justify-center px-4 py-16">
+          <div className="mx-auto max-w-md rounded-3xl border border-white/10 bg-white/[0.035] p-8 text-center animate-scale-in">
+            <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl bg-red-500/10 text-red-300">
+              <Film className="h-7 w-7" aria-hidden="true" />
+            </div>
+            <h1 className="mb-3 text-2xl font-bold">No dashboard data found</h1>
+            <p className="mb-6 text-sm leading-6 text-zinc-400">{error}</p>
+            <Button
+              onClick={handleBackToHome}
+              className="bg-red-500 text-white hover:bg-red-400"
+            >
+              <ArrowLeft className="mr-2 h-4 w-4" /> Choose a history file
+            </Button>
           </div>
-          <h2 className="text-2xl font-bold mb-3">Oops! Something went wrong</h2>
-          <p className="mb-6 text-muted-foreground">{error}</p>
-          <Button 
-            onClick={handleBackToHome}
-            className="bg-gradient-to-r from-primary to-orange-500 hover:from-primary/90 hover:to-orange-500/90"
-          >
-            <ArrowLeft className="mr-2 h-4 w-4" /> Back to Home
-          </Button>
-        </div>
+        </main>
+        <PlaybackFooter />
       </div>
     )
   }
 
   return (
-    <div className="flex flex-col min-h-screen gradient-bg">
-      <header className="sticky top-0 z-50 border-b bg-background/80 backdrop-blur-lg">
-        <div className="container mx-auto flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center gap-3">
-            <Button 
-              variant="ghost" 
-              size="icon" 
-              onClick={handleBackToHome}
-              className="rounded-full hover:bg-primary/10"
-            >
-              <ArrowLeft className="h-4 w-4" />
-              <span className="sr-only">Back to home</span>
-            </Button>
+    <div className="dark flex min-h-screen flex-col bg-zinc-950 text-white">
+      <PlaybackHeader activePlatform="youtube" />
+
+      <main id="main-content" className="relative flex-1 overflow-hidden px-4 py-10 sm:px-6 lg:px-8">
+        <div className="pointer-events-none absolute left-1/2 top-[-20rem] h-[40rem] w-[60rem] -translate-x-1/2 rounded-full bg-red-500/[0.07] blur-[140px]" />
+        <div className="relative mx-auto max-w-7xl space-y-8">
+          <section className="flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
             <div>
-              <h1 className="text-lg font-bold bg-gradient-to-r from-primary to-orange-500 bg-clip-text text-transparent">
-                YouTube History Dashboard
-              </h1>
-              <p className="text-xs text-muted-foreground hidden sm:block">
-                Your personalized viewing insights
-              </p>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-red-300">YouTube history</p>
+              <h1 className="mt-3 text-3xl font-bold tracking-[-0.03em] text-white sm:text-4xl">Your viewing dashboard</h1>
+              <p className="mt-3 max-w-xl text-sm leading-6 text-zinc-400">Patterns, favorites, and viewing rhythms built from your local export.</p>
             </div>
-          </div>
-          <div className="flex items-center gap-2">
-            <div className="hidden sm:flex items-center gap-2 px-4 py-2 rounded-full bg-muted/50 text-sm">
-              <Film className="h-4 w-4 text-primary" />
-              <span className="font-medium">{stats.totalVideos.toLocaleString()}</span>
-              <span className="text-muted-foreground">videos analyzed</span>
+            <div className="flex items-center gap-2 self-start rounded-xl border border-white/[0.08] bg-white/[0.04] px-4 py-2.5 text-sm sm:self-auto">
+              <Film className="h-4 w-4 text-red-300" aria-hidden="true" />
+              <span className="font-mono font-medium tabular-nums text-white">{stats.totalVideos.toLocaleString()}</span>
+              <span className="text-zinc-500">videos analyzed</span>
             </div>
-          </div>
-        </div>
-      </header>
-      
-      <main className="flex-1 py-8 px-4 sm:px-6 lg:px-8">
-        <div className="container mx-auto space-y-8">
+          </section>
+
           {/* Donation Banner */}
           <section className="animate-fade-in">
             <DonationBanner />
@@ -206,10 +213,10 @@ export default function DashboardPage() {
           {/* Charts */}
           <section className="animate-fade-in stagger-5">
             <Tabs defaultValue="daily-views" className="space-y-6">
-              <TabsList className="grid w-full grid-cols-4 h-auto p-1 bg-muted/50 rounded-xl">
+              <TabsList className="grid h-auto w-full grid-cols-4 rounded-xl border border-white/[0.06] bg-white/[0.04] p-1">
                 <TabsTrigger 
                   value="daily-views" 
-                  className="flex items-center gap-2 py-3 rounded-lg data-[state=active]:bg-background data-[state=active]:shadow-sm transition-all"
+                  className="flex items-center gap-2 rounded-lg py-3 transition-all data-[state=active]:bg-white/[0.08] data-[state=active]:text-white"
                 >
                   <Calendar className="h-4 w-4" />
                   <span className="hidden sm:inline">Daily Views</span>
@@ -217,7 +224,7 @@ export default function DashboardPage() {
                 </TabsTrigger>
                 <TabsTrigger 
                   value="top-videos" 
-                  className="flex items-center gap-2 py-3 rounded-lg data-[state=active]:bg-background data-[state=active]:shadow-sm transition-all"
+                  className="flex items-center gap-2 rounded-lg py-3 transition-all data-[state=active]:bg-white/[0.08] data-[state=active]:text-white"
                 >
                   <Film className="h-4 w-4" />
                   <span className="hidden sm:inline">Top Videos</span>
@@ -225,7 +232,7 @@ export default function DashboardPage() {
                 </TabsTrigger>
                 <TabsTrigger 
                   value="viewing-time" 
-                  className="flex items-center gap-2 py-3 rounded-lg data-[state=active]:bg-background data-[state=active]:shadow-sm transition-all"
+                  className="flex items-center gap-2 rounded-lg py-3 transition-all data-[state=active]:bg-white/[0.08] data-[state=active]:text-white"
                 >
                   <Clock className="h-4 w-4" />
                   <span className="hidden sm:inline">Viewing Time</span>
@@ -233,7 +240,7 @@ export default function DashboardPage() {
                 </TabsTrigger>
                 <TabsTrigger 
                   value="channels" 
-                  className="flex items-center gap-2 py-3 rounded-lg data-[state=active]:bg-background data-[state=active]:shadow-sm transition-all"
+                  className="flex items-center gap-2 rounded-lg py-3 transition-all data-[state=active]:bg-white/[0.08] data-[state=active]:text-white"
                 >
                   <Users className="h-4 w-4" />
                   <span className="hidden sm:inline">Channels</span>
@@ -242,12 +249,12 @@ export default function DashboardPage() {
               </TabsList>
 
               <TabsContent value="daily-views" className="mt-6 animate-fade-in">
-                <Card className="border-0 shadow-lg bg-card/50 backdrop-blur">
+                <Card className="border-white/[0.08] bg-white/[0.035] shadow-2xl shadow-black/20 backdrop-blur">
                   <CardHeader className="pb-2">
                     <div className="flex items-start justify-between">
                       <div>
                         <CardTitle className="text-xl flex items-center gap-2">
-                          <span className="w-1.5 h-6 rounded-full bg-gradient-to-b from-red-500 to-orange-500" />
+                          <span className="h-6 w-1.5 rounded-full bg-red-400" />
                           Daily Viewing Activity
                         </CardTitle>
                         <CardDescription className="mt-1">
@@ -263,12 +270,12 @@ export default function DashboardPage() {
               </TabsContent>
 
               <TabsContent value="top-videos" className="mt-6 animate-fade-in">
-                <Card className="border-0 shadow-lg bg-card/50 backdrop-blur">
+                <Card className="border-white/[0.08] bg-white/[0.035] shadow-2xl shadow-black/20 backdrop-blur">
                   <CardHeader className="pb-2">
                     <div className="flex items-start justify-between">
                       <div>
                         <CardTitle className="text-xl flex items-center gap-2">
-                          <span className="w-1.5 h-6 rounded-full bg-gradient-to-b from-orange-500 to-yellow-500" />
+                          <span className="h-6 w-1.5 rounded-full bg-red-400" />
                           Most Watched Videos
                         </CardTitle>
                         <CardDescription className="mt-1">
@@ -284,12 +291,12 @@ export default function DashboardPage() {
               </TabsContent>
 
               <TabsContent value="viewing-time" className="mt-6 animate-fade-in">
-                <Card className="border-0 shadow-lg bg-card/50 backdrop-blur">
+                <Card className="border-white/[0.08] bg-white/[0.035] shadow-2xl shadow-black/20 backdrop-blur">
                   <CardHeader className="pb-2">
                     <div className="flex items-start justify-between">
                       <div>
                         <CardTitle className="text-xl flex items-center gap-2">
-                          <span className="w-1.5 h-6 rounded-full bg-gradient-to-b from-purple-500 to-pink-500" />
+                          <span className="h-6 w-1.5 rounded-full bg-red-400" />
                           Viewing Time Distribution
                         </CardTitle>
                         <CardDescription className="mt-1">
@@ -305,12 +312,12 @@ export default function DashboardPage() {
               </TabsContent>
 
               <TabsContent value="channels" className="mt-6 animate-fade-in">
-                <Card className="border-0 shadow-lg bg-card/50 backdrop-blur">
+                <Card className="border-white/[0.08] bg-white/[0.035] shadow-2xl shadow-black/20 backdrop-blur">
                   <CardHeader className="pb-2">
                     <div className="flex items-start justify-between">
                       <div>
                         <CardTitle className="text-xl flex items-center gap-2">
-                          <span className="w-1.5 h-6 rounded-full bg-gradient-to-b from-pink-500 to-red-500" />
+                          <span className="h-6 w-1.5 rounded-full bg-red-400" />
                           Channel Distribution
                         </CardTitle>
                         <CardDescription className="mt-1">
@@ -329,7 +336,7 @@ export default function DashboardPage() {
 
           {/* Social Share */}
           <section className="animate-fade-in stagger-6">
-            <Card className="border-0 shadow-lg bg-card/50 backdrop-blur">
+            <Card className="border-white/[0.08] bg-white/[0.035] shadow-2xl shadow-black/20 backdrop-blur">
               <CardContent className="pt-6">
                 <SocialShare />
               </CardContent>
@@ -338,17 +345,7 @@ export default function DashboardPage() {
         </div>
       </main>
 
-      <footer className="border-t py-6 bg-background/80 backdrop-blur-lg">
-        <div className="container mx-auto flex flex-col sm:flex-row items-center justify-between gap-4 px-4 sm:px-6 lg:px-8">
-          <p className="text-sm text-muted-foreground">
-            © {new Date().getFullYear()} YouTube History Visualizer
-          </p>
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <div className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
-            Your data stays in your browser
-          </div>
-        </div>
-      </footer>
+      <PlaybackFooter />
     </div>
   )
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,6 +8,39 @@ body {
   font-family: 'Geist', -apple-system, BlinkMacSystemFont, sans-serif;
 }
 
+html {
+  scroll-behavior: smooth;
+  background: #09090b;
+}
+
+body {
+  background: #09090b;
+}
+
+::selection {
+  background: rgba(248, 113, 113, 0.28);
+  color: #ffffff;
+}
+
+:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.82);
+  outline-offset: 3px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
 code, pre, .font-mono {
   font-family: 'Geist Mono', ui-monospace, monospace;
 }
@@ -96,7 +129,9 @@ code, pre, .font-mono {
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground antialiased;
+    @apply antialiased;
+    background: #09090b;
+    color: #fafafa;
   }
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,7 @@ import PromoBanner from '@/components/promo-banner'
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://playbackstats.com'),
-  authors: [{ name: 'YouTube History Visualizer' }],
+  authors: [{ name: 'Playback Stats' }],
   generator: 'Next.js',
 }
 
@@ -27,6 +27,12 @@ export default function RootLayout({
         </Script>
       </head>
       <body>
+        <a
+          href="#main-content"
+          className="fixed left-4 top-4 z-[60] -translate-y-24 rounded-lg bg-white px-4 py-2 text-sm font-semibold text-zinc-950 shadow-xl transition-transform focus:translate-y-0"
+        >
+          Skip to content
+        </a>
         <PromoBanner />
         {children}
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,23 +18,23 @@ import PlaybackHeader from "@/components/playback-header"
 import { Button } from "@/components/ui/button"
 
 export const metadata: Metadata = {
-  title: "YouTube History Analyzer | Private Viewing Stats",
+  title: "YouTube Watch History Analyzer & Stats | Playback Stats",
   description:
-    "Analyze your YouTube watch history locally. Explore viewing trends, channels, repeat watches, and personal patterns without uploading your data.",
+    "Upload Google Takeout watch-history.json to analyze YouTube watch history, viewing stats, top channels, streaks, and trends—privately in your browser.",
   alternates: {
     canonical: "https://playbackstats.com/",
   },
   openGraph: {
     type: "website",
     url: "https://playbackstats.com/",
-    title: "YouTube History Analyzer | Private Viewing Stats",
-    description: "Turn your YouTube watch history into private charts and viewing insights — all in your browser.",
+    title: "YouTube Watch History Analyzer & Stats | Playback Stats",
+    description: "Analyze your YouTube watch history from Google Takeout with private viewing stats, channel rankings, streaks, and trends.",
     siteName: "Playback Stats",
   },
   twitter: {
     card: "summary_large_image",
-    title: "YouTube History Analyzer | Private Viewing Stats",
-    description: "Private, local YouTube history analysis with charts, rankings, and personal insights.",
+    title: "YouTube Watch History Analyzer & Stats | Playback Stats",
+    description: "Analyze your YouTube watch history from Google Takeout with private viewing stats, channel rankings, streaks, and trends.",
   },
   robots: {
     index: true,
@@ -191,13 +191,13 @@ export default function Home() {
               </div>
 
               <h1 className="mt-7 text-balance text-4xl font-bold tracking-[-0.04em] text-white sm:text-5xl lg:text-6xl">
-                See the story behind your{" "}
+                Analyze your{" "}
                 <span className="bg-gradient-to-r from-red-400 via-red-300 to-rose-400 bg-clip-text text-transparent">
-                  YouTube history
+                  YouTube watch history
                 </span>
               </h1>
               <p className="mt-6 max-w-xl text-base leading-7 text-zinc-400 sm:text-lg sm:leading-8">
-                Turn your Google Takeout watch history into a private, interactive look at the creators, routines, and repeat favorites that shaped your time.
+                Upload your Google Takeout watch-history.json to explore viewing stats, top channels, routines, and repeat favorites without sending the file to a server.
               </p>
 
               <div className="mt-9 grid gap-3 sm:grid-cols-3">
@@ -232,9 +232,9 @@ export default function Home() {
           <div className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
             <div className="max-w-2xl">
               <p className="text-xs font-semibold uppercase tracking-[0.2em] text-red-300">Inside your history</p>
-              <h2 id="discover-title" className="mt-4 text-3xl font-bold tracking-tight sm:text-4xl">More than a watch count</h2>
+              <h2 id="discover-title" className="mt-4 text-3xl font-bold tracking-tight sm:text-4xl">YouTube watch history stats, with context</h2>
               <p className="mt-4 text-base leading-7 text-zinc-400">
-                Your export is a timeline. Playback Stats turns it into context you can scan, compare, and understand.
+                This YouTube history analyzer turns your export into patterns you can scan, compare, and understand.
               </p>
             </div>
 
@@ -318,7 +318,7 @@ export default function Home() {
           <div className="mx-auto w-full max-w-5xl px-4 sm:px-6 lg:px-8">
             <div className="max-w-2xl">
               <p className="text-xs font-semibold uppercase tracking-[0.2em] text-red-300">Good to know</p>
-              <h2 id="youtube-faq-title" className="mt-4 text-3xl font-bold tracking-tight sm:text-4xl">Before you analyze</h2>
+              <h2 id="youtube-faq-title" className="mt-4 text-3xl font-bold tracking-tight sm:text-4xl">YouTube history analyzer FAQ</h2>
             </div>
             <div className="mt-10 grid gap-x-10 gap-y-8 md:grid-cols-2">
               {faqs.map((faq) => (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,28 +1,40 @@
+import type { Metadata } from "next"
 import Link from "next/link"
-import { ArrowRight, BarChart2, Clock, Star, Upload, Shield, Zap, Github } from "lucide-react"
-import { Metadata } from "next"
+import {
+  ArrowUpRight,
+  BarChart3,
+  CalendarDays,
+  Clock3,
+  History,
+  Repeat2,
+  ShieldCheck,
+  Sparkles,
+  Users,
+} from "lucide-react"
 
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import FileUploadForm from "@/components/file-upload-form"
+import PlaybackFooter from "@/components/playback-footer"
+import PlaybackHeader from "@/components/playback-header"
+import { Button } from "@/components/ui/button"
 
 export const metadata: Metadata = {
-  title: "YouTube History Visualizer | Analyze Your Viewing Habits",
-  description: "Upload your YouTube watch history and get personalized insights into your viewing patterns. No login required, your data never leaves your browser.",
+  title: "YouTube History Analyzer | Private Viewing Stats",
+  description:
+    "Analyze your YouTube watch history locally. Explore viewing trends, channels, repeat watches, and personal patterns without uploading your data.",
+  alternates: {
+    canonical: "https://playbackstats.com/",
+  },
   openGraph: {
     type: "website",
     url: "https://playbackstats.com/",
-    title: "YouTube History Visualizer | Analyze Your Viewing Habits",
-    description: "Upload your YouTube watch history and get personalized insights into your viewing patterns. No login required, your data never leaves your browser.",
-    siteName: "YouTube History Visualizer",
+    title: "YouTube History Analyzer | Private Viewing Stats",
+    description: "Turn your YouTube watch history into private charts and viewing insights — all in your browser.",
+    siteName: "Playback Stats",
   },
   twitter: {
     card: "summary_large_image",
-    title: "YouTube History Visualizer | Analyze Your Viewing Habits",
-    description: "Upload your YouTube watch history and get personalized insights into your viewing patterns. No login required, your data never leaves your browser.",
-  },
-  alternates: {
-    canonical: "https://playbackstats.com/",
+    title: "YouTube History Analyzer | Private Viewing Stats",
+    description: "Private, local YouTube history analysis with charts, rankings, and personal insights.",
   },
   robots: {
     index: true,
@@ -30,351 +42,297 @@ export const metadata: Metadata = {
   },
 }
 
-const features = [
+const promises = [
+  { icon: CalendarDays, label: "Your timeline", detail: "Daily activity across your export" },
+  { icon: Users, label: "Your channels", detail: "Creators ranked by repeat views" },
+  { icon: Clock3, label: "Your rhythm", detail: "Hours, streaks, and viewing habits" },
+]
+
+const discoveries = [
   {
-    icon: BarChart2,
-    title: "Viewing Trends",
-    description: "See how your viewing habits change over time",
-    detail: "Visualize daily, weekly, and monthly viewing patterns with interactive charts.",
-    gradient: "from-red-500 to-orange-500",
+    icon: BarChart3,
+    title: "Viewing trends",
+    description: "Follow how your viewing changes over days, months, and the full life of your Google history.",
   },
   {
-    icon: Clock,
-    title: "Watch Time Analysis",
-    description: "Understand when you watch the most",
-    detail: "Discover your peak viewing hours and how your habits have evolved over time.",
-    gradient: "from-orange-500 to-yellow-500",
+    icon: Repeat2,
+    title: "Repeat favorites",
+    description: "Find the videos and channels you returned to, with rankings grounded in your own history.",
   },
   {
-    icon: Shield,
-    title: "Private & Secure",
-    description: "Your data stays on your device",
-    detail: "All processing happens in your browser. We never store or transmit your watch history.",
-    gradient: "from-purple-500 to-pink-500",
+    icon: Sparkles,
+    title: "Personal patterns",
+    description: "See your peak hour, favorite day, longest streak, and the shape of your viewing personality.",
+  },
+  {
+    icon: ShieldCheck,
+    title: "Private by design",
+    description: "The browser keeps only compact chart data. Your original Takeout file never reaches a server.",
   },
 ]
 
-const steps = [
-  { number: 1, title: "Export Your Data", description: "Download your watch history from Google Takeout" },
-  { number: 2, title: "Upload the File", description: "Drop your watch-history.json file into our tool" },
-  { number: 3, title: "Explore Insights", description: "View interactive charts and discover your viewing patterns" },
+const exportSteps = [
+  {
+    title: "Open Google Takeout",
+    description: "Sign in, deselect everything, then choose YouTube and YouTube Music.",
+  },
+  {
+    title: "Keep history only",
+    description: "Open the included-data options and leave only history selected before creating the export.",
+  },
+  {
+    title: "Find the JSON file",
+    description: "Unzip the download and locate history/watch-history.json inside the YouTube folder.",
+  },
+  {
+    title: "Explore locally",
+    description: "Choose that JSON file here. Parsing and analysis run inside this browser tab.",
+  },
 ]
 
 const faqs = [
   {
-    question: "Is my data secure?",
-    answer: "Yes, all processing happens directly in your browser. We never store, transmit, or have access to your watch history data.",
+    question: "Does my YouTube history get uploaded?",
+    answer: "No. The file is read and summarized locally in your browser. Playback Stats has no upload endpoint for history files.",
   },
   {
-    question: "Do I need to create an account?",
-    answer: "No, this tool is completely account-free. Simply upload your watch history file and start exploring your data.",
+    question: "Do I need a Google or Playback Stats login?",
+    answer: "No. Export the file from Google Takeout, then analyze it without connecting an account or API key.",
   },
   {
-    question: "How far back does the data go?",
-    answer: "The data goes back as far as your Google account has been tracking your YouTube watch history. For many users, this could be several years.",
+    question: "How far back will the dashboard go?",
+    answer: "As far back as the valid watch records in your export. The available range depends on your Google history settings.",
   },
   {
-    question: "Can I save my visualizations?",
-    answer: "Yes, you can download or screenshot the charts and insights from the dashboard after uploading your data.",
+    question: "What happens when I refresh?",
+    answer: "The original file is never retained. Compact YouTube dashboard data stays only in this browser session and can be cleared by closing it.",
   },
 ]
 
+function DashboardPreview() {
+  const bars = [34, 52, 41, 67, 49, 76, 58, 82, 64, 91, 73, 96]
+
+  return (
+    <div className="relative overflow-hidden rounded-[2rem] border border-white/10 bg-zinc-950/80 p-4 shadow-2xl shadow-black/40 backdrop-blur-xl sm:p-5">
+      <div className="flex items-center justify-between border-b border-white/[0.08] pb-4">
+        <div>
+          <p className="text-xs font-medium text-zinc-500">Dashboard preview</p>
+          <p className="mt-1 text-sm font-semibold text-white">Your viewing history</p>
+        </div>
+        <span className="rounded-lg border border-red-500/20 bg-red-500/10 px-2.5 py-1 font-mono text-[10px] text-red-200">
+          LOCAL DATA
+        </span>
+      </div>
+
+      <div className="mt-4 grid grid-cols-2 gap-3">
+        <div className="rounded-2xl bg-white/[0.04] p-4 ring-1 ring-inset ring-white/[0.06]">
+          <p className="text-[11px] text-zinc-500">Videos watched</p>
+          <p className="mt-3 font-mono text-2xl font-semibold tracking-tight text-white">12,842</p>
+          <p className="mt-1 text-[11px] text-zinc-600">across 6.4 years</p>
+        </div>
+        <div className="rounded-2xl bg-white/[0.04] p-4 ring-1 ring-inset ring-white/[0.06]">
+          <p className="text-[11px] text-zinc-500">Unique channels</p>
+          <p className="mt-3 font-mono text-2xl font-semibold tracking-tight text-white">1,318</p>
+          <p className="mt-1 text-[11px] text-zinc-600">from your export</p>
+        </div>
+      </div>
+
+      <div className="mt-3 rounded-2xl bg-white/[0.04] p-4 ring-1 ring-inset ring-white/[0.06]">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-[11px] text-zinc-500">Viewing activity</p>
+            <p className="mt-1 text-sm font-medium text-white">A year in motion</p>
+          </div>
+          <span className="font-mono text-[10px] text-zinc-600">JAN — DEC</span>
+        </div>
+        <div className="mt-6 flex h-28 items-end gap-2" aria-hidden="true">
+          {bars.map((height, index) => (
+            <span
+              key={`${height}-${index}`}
+              className="flex-1 rounded-t bg-gradient-to-t from-red-700/55 to-red-400 transition-opacity hover:opacity-80"
+              style={{ height: `${height}%` }}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-3 grid gap-3 sm:grid-cols-[1.15fr_0.85fr]">
+        <div className="rounded-2xl bg-red-500/[0.08] p-4 ring-1 ring-inset ring-red-500/15">
+          <p className="text-[11px] text-red-200/60">Peak viewing window</p>
+          <p className="mt-2 font-mono text-lg font-semibold text-white">21:00 — 22:00</p>
+        </div>
+        <div className="rounded-2xl bg-white/[0.04] p-4 ring-1 ring-inset ring-white/[0.06]">
+          <p className="text-[11px] text-zinc-500">Longest streak</p>
+          <p className="mt-2 font-mono text-lg font-semibold text-white">47 days</p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export default function Home() {
   return (
-    <div className="flex flex-col min-h-screen">
-      <header className="sticky top-0 z-50 border-b bg-background/80 backdrop-blur-lg">
-        <div className="container mx-auto flex h-16 items-center px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center gap-2">
-            <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-red-500 to-orange-500 flex items-center justify-center">
-              <Zap className="h-4 w-4 text-white" />
-            </div>
-            <h1 className="text-lg font-bold">YouTube History Visualizer</h1>
-          </div>
-          <nav className="ml-auto flex items-center gap-6">
-            <Link href="#how-it-works" className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors">
-              How It Works
-            </Link>
-            <Link href="#faq" className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors">
-              FAQ
-            </Link>
-            <Link 
-              href="https://github.com/ronething/yt-history" 
-              target="_blank" 
-              rel="noopener noreferrer"
-              className="hidden sm:flex items-center gap-2 px-3 py-1.5 rounded-full bg-muted/50 hover:bg-muted text-sm font-medium transition-colors"
-            >
-              <Github className="h-4 w-4" />
-              GitHub
-            </Link>
-          </nav>
-        </div>
-      </header>
+    <div className="dark min-h-screen bg-zinc-950 text-white">
+      <PlaybackHeader activePlatform="youtube" guideHref="#how-to-export" />
 
-      <main className="flex-1">
-        {/* Hero Section */}
-        <section className="relative w-full py-20 md:py-32 overflow-hidden">
-          {/* Background decoration */}
-          <div className="absolute inset-0 gradient-bg" />
-          <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-red-500/10 rounded-full blur-3xl" />
-          <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-orange-500/10 rounded-full blur-3xl" />
-          
-          <div className="container relative mx-auto px-4 md:px-6">
-            <div className="grid gap-12 lg:grid-cols-2 lg:gap-16 items-center">
-              <div className="space-y-8 animate-fade-in">
-                <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/10 text-primary text-sm font-medium">
-                  <span className="w-2 h-2 rounded-full bg-primary animate-pulse" />
-                  100% Private - No data leaves your browser
-                </div>
-                
-                <h2 className="text-4xl font-bold tracking-tight sm:text-5xl md:text-6xl">
-                  Discover Your{" "}
-                  <span className="bg-gradient-to-r from-red-500 to-orange-500 bg-clip-text text-transparent">
-                    YouTube
-                  </span>{" "}
-                  Viewing Habits
-                </h2>
-                
-                <p className="text-lg text-muted-foreground max-w-xl">
-                  Upload your YouTube watch history and get personalized insights into your viewing patterns. 
-                  No login required, and your data never leaves your browser.
-                </p>
-                
-                <div className="flex flex-wrap gap-3">
-                  <Button 
-                    size="lg"
-                    className="bg-gradient-to-r from-red-500 to-orange-500 hover:from-red-600 hover:to-orange-600 text-white shadow-lg shadow-red-500/25 transition-all hover:shadow-xl hover:shadow-red-500/30 hover:scale-105"
-                    asChild
-                  >
-                    <Link href="#upload" className="flex items-center gap-2">
-                      Get Started <ArrowRight className="h-4 w-4" />
-                    </Link>
-                  </Button>
-                  <Button variant="outline" size="lg" asChild>
-                    <Link href="#how-to-export">
-                      How to Export Data
-                    </Link>
-                  </Button>
-                  <Button variant="ghost" size="lg" asChild>
-                    <Link 
-                      href="https://github.com/ronething/yt-history" 
-                      target="_blank" 
-                      rel="noopener noreferrer" 
-                      className="flex items-center gap-2"
-                    >
-                      <Star className="h-4 w-4" /> Star on GitHub
-                    </Link>
-                  </Button>
-                </div>
+      <main id="main-content">
+        <section id="upload" className="relative scroll-mt-20 overflow-hidden border-b border-white/[0.07]">
+          <div className="pointer-events-none absolute inset-0">
+            <div className="absolute left-[-14rem] top-[-12rem] h-[32rem] w-[32rem] rounded-full bg-red-500/10 blur-[100px]" />
+            <div className="absolute right-[-12rem] top-[8rem] h-[28rem] w-[28rem] rounded-full bg-rose-400/[0.06] blur-[110px]" />
+            <div className="absolute inset-0 bg-[linear-gradient(rgba(255,255,255,0.025)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.025)_1px,transparent_1px)] bg-[size:48px_48px] [mask-image:linear-gradient(to_bottom,black,transparent_82%)]" />
+          </div>
+
+          <div className="relative mx-auto grid min-h-[720px] w-full max-w-7xl items-center gap-12 px-4 py-16 sm:px-6 sm:py-20 lg:grid-cols-[1.02fr_0.98fr] lg:px-8 lg:py-24">
+            <div className="max-w-2xl">
+              <div className="inline-flex items-center gap-2 rounded-full border border-red-500/25 bg-red-500/10 px-3 py-1.5 text-xs font-medium text-red-200">
+                <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+                100% local — your file never leaves this browser
               </div>
-              
-              <div className="flex justify-center animate-fade-in stagger-2">
-                <div className="relative">
-                  <div className="absolute -inset-4 bg-gradient-to-r from-red-500/20 to-orange-500/20 rounded-2xl blur-2xl" />
-                  <img
-                    src="/youtube-analytics-overview.png"
-                    alt="YouTube Analytics Dashboard"
-                    className="relative rounded-2xl object-cover border shadow-2xl"
-                    width={600}
-                    height={400}
-                  />
-                </div>
+
+              <h1 className="mt-7 text-balance text-4xl font-bold tracking-[-0.04em] text-white sm:text-5xl lg:text-6xl">
+                See the story behind your{" "}
+                <span className="bg-gradient-to-r from-red-400 via-red-300 to-rose-400 bg-clip-text text-transparent">
+                  YouTube history
+                </span>
+              </h1>
+              <p className="mt-6 max-w-xl text-base leading-7 text-zinc-400 sm:text-lg sm:leading-8">
+                Turn your Google Takeout watch history into a private, interactive look at the creators, routines, and repeat favorites that shaped your time.
+              </p>
+
+              <div className="mt-9 grid gap-3 sm:grid-cols-3">
+                {promises.map((item) => {
+                  const Icon = item.icon
+                  return (
+                    <div key={item.label} className="rounded-2xl border border-white/[0.08] bg-white/[0.035] p-4 backdrop-blur">
+                      <Icon className="h-4 w-4 text-red-300" aria-hidden="true" />
+                      <p className="mt-4 text-sm font-semibold text-white">{item.label}</p>
+                      <p className="mt-1 text-xs leading-5 text-zinc-500">{item.detail}</p>
+                    </div>
+                  )
+                })}
+              </div>
+
+              <div className="mt-8 flex items-start gap-3 text-sm leading-6 text-zinc-500">
+                <History className="mt-1 h-4 w-4 shrink-0 text-red-300" aria-hidden="true" />
+                <p>No YouTube login, API key, or server upload. Your browser builds a compact dashboard from the exported JSON.</p>
               </div>
             </div>
-          </div>
-        </section>
 
-        {/* Upload Section */}
-        <section id="upload" className="w-full py-20 md:py-28 bg-muted/30">
-          <div className="container mx-auto px-4 md:px-6">
-            <div className="flex flex-col items-center justify-center space-y-8 text-center">
-              <div className="space-y-4 max-w-2xl animate-fade-in">
-                <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
-                  Upload Your Watch History
-                </h2>
-                <p className="text-muted-foreground text-lg">
-                  Simply upload your watch-history.json file from Google Takeout to visualize your YouTube viewing patterns.
-                </p>
-              </div>
-              <div className="w-full max-w-lg mx-auto animate-fade-in stagger-2">
+            <div className="relative lg:pl-4">
+              <div className="absolute -inset-6 rounded-[2rem] bg-red-500/[0.1] blur-2xl" />
+              <div className="relative rounded-[2rem] border border-white/10 bg-zinc-950/70 p-3 shadow-2xl shadow-black/30 backdrop-blur-xl sm:p-5">
                 <FileUploadForm />
               </div>
             </div>
           </div>
         </section>
 
-        {/* Features Section */}
-        <section id="features" className="w-full py-20 md:py-28">
-          <div className="container mx-auto px-4 md:px-6">
-            <div className="flex flex-col items-center justify-center space-y-4 text-center mb-12">
-              <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">Powerful Insights</h2>
-              <p className="text-muted-foreground text-lg max-w-2xl">
-                Discover patterns in your YouTube viewing history with our comprehensive analytics.
+        <section className="border-b border-white/[0.07] py-20 sm:py-24" aria-labelledby="discover-title">
+          <div className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+            <div className="max-w-2xl">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-red-300">Inside your history</p>
+              <h2 id="discover-title" className="mt-4 text-3xl font-bold tracking-tight sm:text-4xl">More than a watch count</h2>
+              <p className="mt-4 text-base leading-7 text-zinc-400">
+                Your export is a timeline. Playback Stats turns it into context you can scan, compare, and understand.
               </p>
             </div>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-              {features.map((feature, index) => {
-                const Icon = feature.icon
+
+            <div className="mt-10 grid gap-4 sm:grid-cols-2">
+              {discoveries.map((item) => {
+                const Icon = item.icon
                 return (
-                  <Card 
-                    key={feature.title} 
-                    className="group relative overflow-hidden border-0 bg-card/50 backdrop-blur hover:shadow-xl transition-all duration-300 animate-fade-in"
-                    style={{ animationDelay: `${index * 100}ms` }}
-                  >
-                    <div className={`absolute inset-0 bg-gradient-to-br ${feature.gradient} opacity-0 group-hover:opacity-5 transition-opacity duration-300`} />
-                    <CardHeader>
-                      <div className={`w-12 h-12 rounded-xl bg-gradient-to-br ${feature.gradient} flex items-center justify-center mb-4 shadow-lg`}>
-                        <Icon className="h-6 w-6 text-white" />
-                      </div>
-                      <CardTitle className="flex items-center gap-2 text-xl">
-                        {feature.title}
-                      </CardTitle>
-                      <CardDescription>{feature.description}</CardDescription>
-                    </CardHeader>
-                    <CardContent>
-                      <p className="text-muted-foreground">{feature.detail}</p>
-                    </CardContent>
-                  </Card>
+                  <article key={item.title} className="rounded-3xl border border-white/[0.08] bg-white/[0.03] p-6 transition-colors hover:bg-white/[0.05] sm:p-7">
+                    <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-red-500/[0.12] text-red-300">
+                      <Icon className="h-5 w-5" aria-hidden="true" />
+                    </span>
+                    <h3 className="mt-6 text-lg font-semibold text-white">{item.title}</h3>
+                    <p className="mt-2 max-w-lg text-sm leading-6 text-zinc-400">{item.description}</p>
+                  </article>
                 )
               })}
             </div>
+
+            <div className="relative mt-4">
+              <div className="absolute -inset-6 rounded-[2rem] bg-red-500/[0.06] blur-2xl" />
+              <DashboardPreview />
+            </div>
           </div>
         </section>
 
-        {/* How It Works Section */}
-        <section id="how-it-works" className="w-full py-20 md:py-28 bg-muted/30">
-          <div className="container mx-auto px-4 md:px-6">
-            <div className="flex flex-col items-center justify-center space-y-4 text-center mb-12">
-              <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">How It Works</h2>
-              <p className="text-muted-foreground text-lg max-w-2xl">
-                Our tool makes it easy to visualize your YouTube viewing history in just a few steps.
+        <section id="how-to-export" className="scroll-mt-20 border-b border-white/[0.07] py-20 sm:py-24">
+          <div className="mx-auto grid w-full max-w-7xl gap-12 px-4 sm:px-6 lg:grid-cols-[0.8fr_1.2fr] lg:px-8">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-red-300">Bring your own data</p>
+              <h2 className="mt-4 text-3xl font-bold tracking-tight sm:text-4xl">How to export YouTube history</h2>
+              <p className="mt-5 max-w-xl text-base leading-7 text-zinc-400">
+                Google Takeout lets you download watch history without granting this site access to your account.
               </p>
+              <Button asChild className="mt-7 bg-red-500 font-semibold text-white hover:bg-red-400">
+                <Link href="https://takeout.google.com/" target="_blank" rel="noopener noreferrer">
+                  Open Google Takeout
+                  <ArrowUpRight className="ml-2 h-4 w-4" aria-hidden="true" />
+                </Link>
+              </Button>
             </div>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-4xl mx-auto">
-              {steps.map((step, index) => (
-                <div 
-                  key={step.number} 
-                  className="flex flex-col items-center space-y-4 animate-fade-in"
-                  style={{ animationDelay: `${index * 100}ms` }}
-                >
-                  <div className="relative">
-                    <div className="absolute inset-0 bg-gradient-to-br from-red-500 to-orange-500 rounded-2xl blur-lg opacity-50" />
-                    <div className="relative flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-to-br from-red-500 to-orange-500 text-white text-2xl font-bold shadow-lg">
-                      {step.number}
-                    </div>
-                  </div>
-                  <h3 className="text-xl font-bold">{step.title}</h3>
-                  <p className="text-muted-foreground text-center">{step.description}</p>
-                </div>
+
+            <ol className="grid gap-3 sm:grid-cols-2">
+              {exportSteps.map((step, index) => (
+                <li key={step.title} className="rounded-2xl border border-white/10 bg-white/[0.03] p-5">
+                  <span className="font-mono text-xs font-semibold text-red-300">0{index + 1}</span>
+                  <h3 className="mt-4 font-semibold text-white">{step.title}</h3>
+                  <p className="mt-2 text-sm leading-6 text-zinc-400">{step.description}</p>
+                </li>
               ))}
-            </div>
+            </ol>
           </div>
         </section>
 
-        {/* How to Export Section */}
-        <section id="how-to-export" className="w-full py-20 md:py-28">
-          <div className="container mx-auto px-4 md:px-6">
-            <div className="flex flex-col items-center justify-center space-y-4 text-center mb-12">
-              <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
-                How to Export YouTube History
-              </h2>
-              <p className="text-muted-foreground text-lg max-w-2xl">
-                Follow these steps to download your YouTube watch history from Google Takeout.
-              </p>
-            </div>
-            <div className="w-full max-w-3xl mx-auto">
-              <ol className="space-y-3">
+        <section className="border-b border-white/[0.07] py-20 sm:py-24" aria-labelledby="privacy-title">
+          <div className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+            <div className="grid overflow-hidden rounded-3xl border border-red-500/20 bg-gradient-to-br from-red-500/[0.12] via-white/[0.025] to-transparent lg:grid-cols-[1fr_0.9fr]">
+              <div className="p-7 sm:p-10">
+                <ShieldCheck className="h-7 w-7 text-red-300" aria-hidden="true" />
+                <h2 id="privacy-title" className="mt-6 text-2xl font-bold tracking-tight sm:text-3xl">Personal data should stay personal</h2>
+                <p className="mt-4 max-w-xl text-sm leading-7 text-zinc-300">
+                  The original Takeout file is read locally and never sent to Playback Stats. Only compact dashboard summaries are stored for the current browser session.
+                </p>
+              </div>
+              <div className="grid gap-px border-t border-white/10 bg-white/10 sm:grid-cols-3 lg:grid-cols-1 lg:border-l lg:border-t-0">
                 {[
-                  <>Visit <a href="https://takeout.google.com/" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline font-medium">Google Takeout</a> and ensure you're logged into the correct Google account.</>,
-                  <>In the product list, deselect all items, then select only "YouTube and YouTube Music".</>,
-                  <>Click the "All YouTube data included" button next to "YouTube and YouTube Music".</>,
-                  <>In the pop-up options, deselect all items, keeping only "history" checked.</>,
-                  <>Click "OK", then scroll to the bottom of the page and click "Next step".</>,
-                  <>Choose your preferred export frequency, file type, and size. For a one-time export, keep the default settings.</>,
-                  <>Click "Create export" and wait for Google to prepare your data (this may take a few minutes to several hours).</>,
-                  <>Once ready, you'll receive an email. Click the download link in the email.</>,
-                  <>Download and unzip the file.</>,
-                  <>In the extracted folder, locate the <code className="bg-muted px-2 py-1 rounded text-sm font-mono">Takeout/YouTube and YouTube Music/history/watch-history.json</code> file.</>,
-                ].map((content, index) => (
-                  <li 
-                    key={index} 
-                    className="flex gap-4 p-4 bg-card/50 backdrop-blur rounded-xl border border-border/50 animate-fade-in"
-                    style={{ animationDelay: `${index * 50}ms` }}
-                  >
-                    <span className="flex-shrink-0 flex items-center justify-center w-8 h-8 rounded-lg bg-gradient-to-br from-red-500 to-orange-500 text-white text-sm font-bold">
-                      {index + 1}
-                    </span>
-                    <span className="text-muted-foreground">{content}</span>
-                  </li>
+                  ["Browser only", "No upload endpoint"],
+                  ["Session only", "Close to clear"],
+                  ["Open source", "Inspect every rule"],
+                ].map(([title, detail]) => (
+                  <div key={title} className="bg-zinc-950/90 p-5 sm:p-6">
+                    <p className="text-sm font-semibold text-white">{title}</p>
+                    <p className="mt-1 text-xs text-zinc-500">{detail}</p>
+                  </div>
                 ))}
-              </ol>
+              </div>
             </div>
           </div>
         </section>
 
-        {/* FAQ Section */}
-        <section id="faq" className="w-full py-20 md:py-28 bg-muted/30">
-          <div className="container mx-auto px-4 md:px-6">
-            <div className="flex flex-col items-center justify-center space-y-4 text-center mb-12">
-              <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
-                Frequently Asked Questions
-              </h2>
-              <p className="text-muted-foreground text-lg max-w-2xl">
-                Common questions about our YouTube History Visualizer.
-              </p>
+        <section className="py-20 sm:py-24" aria-labelledby="youtube-faq-title">
+          <div className="mx-auto w-full max-w-5xl px-4 sm:px-6 lg:px-8">
+            <div className="max-w-2xl">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-red-300">Good to know</p>
+              <h2 id="youtube-faq-title" className="mt-4 text-3xl font-bold tracking-tight sm:text-4xl">Before you analyze</h2>
             </div>
-            <div className="w-full max-w-3xl mx-auto space-y-4">
-              {faqs.map((faq, index) => (
-                <Card 
-                  key={index} 
-                  className="border-0 bg-card/50 backdrop-blur animate-fade-in"
-                  style={{ animationDelay: `${index * 100}ms` }}
-                >
-                  <CardHeader className="pb-3">
-                    <CardTitle className="text-lg">{faq.question}</CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <p className="text-muted-foreground">{faq.answer}</p>
-                  </CardContent>
-                </Card>
+            <div className="mt-10 grid gap-x-10 gap-y-8 md:grid-cols-2">
+              {faqs.map((faq) => (
+                <article key={faq.question} className="border-t border-white/10 pt-5">
+                  <h3 className="font-semibold text-white">{faq.question}</h3>
+                  <p className="mt-2 text-sm leading-6 text-zinc-400">{faq.answer}</p>
+                </article>
               ))}
             </div>
           </div>
         </section>
       </main>
 
-      <footer className="border-t py-8 bg-background/80 backdrop-blur-lg">
-        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex flex-col md:flex-row items-center justify-between gap-4">
-            <div className="flex items-center gap-2">
-              <div className="w-6 h-6 rounded-lg bg-gradient-to-br from-red-500 to-orange-500 flex items-center justify-center">
-                <Zap className="h-3 w-3 text-white" />
-              </div>
-              <p className="text-sm text-muted-foreground">
-                © {new Date().getFullYear()} YouTube History Visualizer. All rights reserved.
-              </p>
-            </div>
-            <p className="text-sm text-muted-foreground">
-              Made with ❤️ by <a href="https://forgetimer.com" target="_blank" className="text-primary hover:underline">Forgetimer</a>
-            </p>
-            <div className="flex items-center gap-6">
-              <Link href="/privacy" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
-                Privacy Policy
-              </Link>
-              <Link href="/terms" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
-                Terms of Service
-              </Link>
-              <Link 
-                href="https://github.com/ronething/yt-history" 
-                target="_blank" 
-                rel="noopener noreferrer" 
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-              >
-                GitHub
-              </Link>
-            </div>
-          </div>
-        </div>
-      </footer>
+      <PlaybackFooter />
     </div>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -71,6 +71,24 @@ const discoveries = [
   },
 ]
 
+const analysisDetails = [
+  {
+    title: "Viewing activity",
+    description:
+      "Count watch events by day, month, weekday, and hour to see when your YouTube activity rises or falls.",
+  },
+  {
+    title: "Videos and channels",
+    description:
+      "Rank repeat videos, compare channel frequency, and measure how concentrated or varied your viewing history is.",
+  },
+  {
+    title: "Habits over time",
+    description:
+      "Find your first recorded video, busiest day, peak viewing hour, favorite weekday, and longest active streak.",
+  },
+]
+
 const exportSteps = [
   {
     title: "Open Google Takeout",
@@ -107,66 +125,50 @@ const faqs = [
     question: "What happens when I refresh?",
     answer: "The original file is never retained. Compact YouTube dashboard data stays only in this browser session and can be cleared by closing it.",
   },
+  {
+    question: "Can this calculate my total YouTube watch time?",
+    answer:
+      "No. Google Takeout watch history records when a video was watched, but it does not provide reliable minutes watched for each event. Playback Stats reports viewing activity rather than inventing a watch-time estimate.",
+  },
+  {
+    question: "Why might the totals differ from YouTube itself?",
+    answer:
+      "The analyzer can only count valid records present in the exported JSON. Deleted history, paused history, private or unavailable videos, and changes to your Google activity settings can affect what the export contains.",
+  },
 ]
 
-function DashboardPreview() {
-  const bars = [34, 52, 41, 67, 49, 76, 58, 82, 64, 91, 73, 96]
-
+function AnalysisMethod() {
   return (
-    <div className="relative overflow-hidden rounded-[2rem] border border-white/10 bg-zinc-950/80 p-4 shadow-2xl shadow-black/40 backdrop-blur-xl sm:p-5">
-      <div className="flex items-center justify-between border-b border-white/[0.08] pb-4">
-        <div>
-          <p className="text-xs font-medium text-zinc-500">Dashboard preview</p>
-          <p className="mt-1 text-sm font-semibold text-white">Your viewing history</p>
-        </div>
-        <span className="rounded-lg border border-red-500/20 bg-red-500/10 px-2.5 py-1 font-mono text-[10px] text-red-200">
-          LOCAL DATA
-        </span>
+    <article
+      aria-labelledby="youtube-analysis-method-title"
+      className="relative overflow-hidden rounded-[2rem] border border-white/10 bg-zinc-950/80 p-6 shadow-2xl shadow-black/40 backdrop-blur-xl sm:p-8"
+    >
+      <div className="max-w-3xl">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-red-300">How the analysis works</p>
+        <h3 id="youtube-analysis-method-title" className="mt-4 text-2xl font-bold tracking-tight text-white sm:text-3xl">
+          What this YouTube history analyzer measures
+        </h3>
+        <p className="mt-4 text-sm leading-7 text-zinc-400 sm:text-base">
+          Google Takeout&apos;s <code className="font-mono text-red-200">watch-history.json</code> is a chronological list of viewing events. Playback Stats reads each valid video title, channel, and timestamp, then groups those records into useful comparisons without contacting YouTube or Google.
+        </p>
       </div>
 
-      <div className="mt-4 grid grid-cols-2 gap-3">
-        <div className="rounded-2xl bg-white/[0.04] p-4 ring-1 ring-inset ring-white/[0.06]">
-          <p className="text-[11px] text-zinc-500">Videos watched</p>
-          <p className="mt-3 font-mono text-2xl font-semibold tracking-tight text-white">12,842</p>
-          <p className="mt-1 text-[11px] text-zinc-600">across 6.4 years</p>
-        </div>
-        <div className="rounded-2xl bg-white/[0.04] p-4 ring-1 ring-inset ring-white/[0.06]">
-          <p className="text-[11px] text-zinc-500">Unique channels</p>
-          <p className="mt-3 font-mono text-2xl font-semibold tracking-tight text-white">1,318</p>
-          <p className="mt-1 text-[11px] text-zinc-600">from your export</p>
-        </div>
-      </div>
-
-      <div className="mt-3 rounded-2xl bg-white/[0.04] p-4 ring-1 ring-inset ring-white/[0.06]">
-        <div className="flex items-center justify-between">
-          <div>
-            <p className="text-[11px] text-zinc-500">Viewing activity</p>
-            <p className="mt-1 text-sm font-medium text-white">A year in motion</p>
+      <dl className="mt-8 grid gap-3 md:grid-cols-3">
+        {analysisDetails.map((item) => (
+          <div key={item.title} className="rounded-2xl bg-white/[0.04] p-5 ring-1 ring-inset ring-white/[0.06]">
+            <dt className="font-semibold text-white">{item.title}</dt>
+            <dd className="mt-2 text-sm leading-6 text-zinc-400">{item.description}</dd>
           </div>
-          <span className="font-mono text-[10px] text-zinc-600">JAN — DEC</span>
-        </div>
-        <div className="mt-6 flex h-28 items-end gap-2" aria-hidden="true">
-          {bars.map((height, index) => (
-            <span
-              key={`${height}-${index}`}
-              className="flex-1 rounded-t bg-gradient-to-t from-red-700/55 to-red-400 transition-opacity hover:opacity-80"
-              style={{ height: `${height}%` }}
-            />
-          ))}
-        </div>
-      </div>
+        ))}
+      </dl>
 
-      <div className="mt-3 grid gap-3 sm:grid-cols-[1.15fr_0.85fr]">
-        <div className="rounded-2xl bg-red-500/[0.08] p-4 ring-1 ring-inset ring-red-500/15">
-          <p className="text-[11px] text-red-200/60">Peak viewing window</p>
-          <p className="mt-2 font-mono text-lg font-semibold text-white">21:00 — 22:00</p>
-        </div>
-        <div className="rounded-2xl bg-white/[0.04] p-4 ring-1 ring-inset ring-white/[0.06]">
-          <p className="text-[11px] text-zinc-500">Longest streak</p>
-          <p className="mt-2 font-mono text-lg font-semibold text-white">47 days</p>
-        </div>
+      <div className="mt-4 rounded-2xl border border-amber-300/15 bg-amber-300/[0.06] p-5">
+        <p className="text-sm font-semibold text-amber-100">A deliberate limitation</p>
+        <p className="mt-2 text-sm leading-6 text-zinc-400">
+          YouTube&apos;s export does not include dependable watch duration for each history event. The dashboard therefore reports views and viewing patterns, not a made-up total watch-time number.
+        </p>
       </div>
-    </div>
+    </article>
   )
 }
 
@@ -255,7 +257,7 @@ export default function Home() {
 
             <div className="relative mt-4">
               <div className="absolute -inset-6 rounded-[2rem] bg-red-500/[0.06] blur-2xl" />
-              <DashboardPreview />
+              <AnalysisMethod />
             </div>
           </div>
         </section>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,20 +1,19 @@
-import Link from "next/link"
-import { ArrowLeft } from "lucide-react"
 import { Metadata } from "next"
 
-import { Button } from "@/components/ui/button"
+import PlaybackFooter from "@/components/playback-footer"
+import PlaybackHeader from "@/components/playback-header"
 
 export const metadata: Metadata = {
-  title: "Privacy Policy | YouTube History Visualizer",
-  description: "Privacy policy and data handling practices for the YouTube History Visualizer tool.",
+  title: "Privacy Policy | Playback Stats",
+  description: "Privacy and local data-processing practices for Playback Stats.",
   openGraph: {
-    title: "Privacy Policy | YouTube History Visualizer",
-    description: "Privacy policy and data handling practices for the YouTube History Visualizer tool.",
+    title: "Privacy Policy | Playback Stats",
+    description: "Privacy and local data-processing practices for Playback Stats.",
     url: "https://playbackstats.com/privacy",
   },
   twitter: {
-    title: "Privacy Policy | YouTube History Visualizer",
-    description: "Privacy policy and data handling practices for the YouTube History Visualizer tool.",
+    title: "Privacy Policy | Playback Stats",
+    description: "Privacy and local data-processing practices for Playback Stats.",
   },
   alternates: {
     canonical: "https://playbackstats.com/privacy",
@@ -23,34 +22,22 @@ export const metadata: Metadata = {
 
 export default function PrivacyPolicy() {
   return (
-    <div className="flex flex-col min-h-screen">
-      <header className="border-b">
-        <div className="container mx-auto flex h-16 items-center px-4 sm:px-6 lg:px-8">
-          <Link href="/" className="flex items-center gap-2">
-            <h1 className="text-lg font-semibold">YouTube History Visualizer</h1>
-          </Link>
-          <nav className="ml-auto flex gap-4">
-            <Button variant="ghost" size="sm" asChild>
-              <Link href="/" className="flex items-center gap-1">
-                <ArrowLeft className="h-4 w-4" /> Back to Home
-              </Link>
-            </Button>
-          </nav>
-        </div>
-      </header>
-      <main className="flex-1">
-        <div className="container mx-auto py-12 px-4 md:px-6">
-          <div className="max-w-3xl mx-auto space-y-8">
+    <div className="dark flex min-h-screen flex-col bg-zinc-950 text-white">
+      <PlaybackHeader />
+      <main id="main-content" className="flex-1">
+        <div className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
+          <article className="mx-auto max-w-3xl space-y-10 text-sm leading-7 text-zinc-300 [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:tracking-tight [&_h2]:text-white [&_li]:pl-1 [&_strong]:font-semibold [&_strong]:text-white sm:text-base">
             <div>
-              <h1 className="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl mb-4">Privacy Policy</h1>
-              <p className="text-gray-500">Last Updated: {new Date().toLocaleDateString()}</p>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">Playback Stats</p>
+              <h1 className="mt-4 text-4xl font-bold tracking-[-0.04em] text-white sm:text-5xl">Privacy Policy</h1>
+              <p className="mt-4 text-sm text-zinc-500">Last updated: {new Date().toLocaleDateString()}</p>
             </div>
 
             <section className="space-y-4">
               <h2 className="text-2xl font-bold">Introduction</h2>
               <p>
-                At YouTube History Visualizer, we take your privacy seriously. This Privacy Policy explains how we
-                handle your data when you use our service to visualize your YouTube watch history.
+                Playback Stats helps you visualize personal YouTube and Spotify history. This policy explains which
+                data stays in your browser and which limited site-level analytics may be collected.
               </p>
             </section>
 
@@ -58,12 +45,12 @@ export default function PrivacyPolicy() {
               <h2 className="text-2xl font-bold">Data Collection and Processing</h2>
               <p>
                 <strong>Client-Side Processing Only:</strong> Our service operates entirely within your web browser.
-                When you upload your YouTube watch history file:
+                When you select a supported YouTube or Spotify history file:
               </p>
               <ul className="list-disc pl-6 space-y-2">
                 <li>The file is processed locally on your device</li>
-                <li>Your data is never sent to our servers</li>
-                <li>We do not store, collect, or transmit any of your personal data</li>
+                <li>Your selected history file is never sent to our servers</li>
+                <li>We do not store or transmit its titles, artists, playback records, or generated insights</li>
                 <li>
                   The data is temporarily stored in your browser&apos;s memory only for the duration of your session
                 </li>
@@ -73,24 +60,25 @@ export default function PrivacyPolicy() {
             <section className="space-y-4">
               <h2 className="text-2xl font-bold">Information Usage</h2>
               <p>
-                Since we do not collect any personal data, we do not use your information for any purposes beyond
-                providing the visualization service directly in your browser.
+                File contents are used only to calculate the visualizations shown in your current browser session.
+                Spotify parsing uses a field allowlist and ignores account, IP address, location, and technical-log data.
               </p>
             </section>
 
             <section className="space-y-4">
-              <h2 className="text-2xl font-bold">Cookies and Tracking</h2>
+              <h2 className="text-2xl font-bold">Site Analytics</h2>
               <p>
-                Our website does not use cookies or tracking technologies to monitor your activity or collect
-                information about you.
+                The website may use aggregate analytics for page views, file-download events, and outbound-link
+                events. Uploaded history contents, file contents, analysis results, track titles, and artist names are
+                not included in those analytics events.
               </p>
             </section>
 
             <section className="space-y-4">
               <h2 className="text-2xl font-bold">Third-Party Services</h2>
               <p>
-                We do not integrate with third-party services that would collect your data. All processing and
-                visualization happen locally in your web browser.
+                History processing and visualization happen locally in your browser. Links to services such as
+                Spotify, Google, GitHub, or other external sites are governed by those services&apos; own privacy policies.
               </p>
             </section>
 
@@ -123,24 +111,10 @@ export default function PrivacyPolicy() {
                 support@playbackstats.com
               </p>
             </section>
-          </div>
+          </article>
         </div>
       </main>
-      <footer className="border-t py-6">
-        <div className="container mx-auto flex flex-col md:flex-row items-center justify-between px-4 sm:px-6 lg:px-8">
-          <p className="text-center text-sm leading-loose text-gray-500 md:text-left">
-            © {new Date().getFullYear()} YouTube History Visualizer. All rights reserved.
-          </p>
-          <div className="flex items-center gap-4">
-            <Link href="/privacy" className="text-sm text-gray-500 hover:underline">
-              Privacy Policy
-            </Link>
-            <Link href="/terms" className="text-sm text-gray-500 hover:underline">
-              Terms of Service
-            </Link>
-          </div>
-        </div>
-      </footer>
+      <PlaybackFooter />
     </div>
   )
-} 
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -12,6 +12,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 1.0,
     },
     {
+      url: `${baseUrl}/spotify`,
+      lastModified: currentDate,
+      changeFrequency: 'monthly',
+      priority: 0.9,
+    },
+    {
       url: `${baseUrl}/privacy`,
       lastModified: currentDate,
       changeFrequency: 'yearly',
@@ -24,4 +30,4 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.5,
     },
   ]
-} 
+}

--- a/app/spotify/page.tsx
+++ b/app/spotify/page.tsx
@@ -1,0 +1,242 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import {
+  ArrowUpRight,
+  BarChart3,
+  Clock3,
+  HeartPulse,
+  ShieldCheck,
+  Sparkles,
+} from "lucide-react"
+
+import PlaybackFooter from "@/components/playback-footer"
+import PlaybackHeader from "@/components/playback-header"
+import SpotifyAnalyzer from "@/components/spotify/spotify-analyzer"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+export const metadata: Metadata = {
+  title: "Spotify History Analyzer | Private Listening Stats",
+  description:
+    "Analyze your Spotify streaming history locally. Explore listening time, top artists, tracks, trends, and playback habits without uploading your data.",
+  alternates: {
+    canonical: "https://playbackstats.com/spotify",
+  },
+  openGraph: {
+    type: "website",
+    url: "https://playbackstats.com/spotify",
+    siteName: "Playback Stats",
+    title: "Spotify History Analyzer | Private Listening Stats",
+    description:
+      "Turn your Spotify streaming history into private charts and personal listening insights — all in your browser.",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Spotify History Analyzer | Private Listening Stats",
+    description: "Private, local Spotify listening analysis with charts, rankings, and personal insights.",
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+}
+
+const discoveries = [
+  {
+    icon: Clock3,
+    title: "The shape of your time",
+    description: "Follow listening hours across months, years, weekdays, and every hour on the clock.",
+  },
+  {
+    icon: BarChart3,
+    title: "Favorites with context",
+    description: "See artists ranked by time and tracks ranked by qualified 30-second plays.",
+  },
+  {
+    icon: Sparkles,
+    title: "A story grounded in data",
+    description: "Get concise local insights about your rhythm, discovery mix, streaks, and repeat favorites.",
+  },
+  {
+    icon: HeartPulse,
+    title: "How you listen",
+    description: "Extended exports reveal skip, shuffle, offline, platform, and natural-ending patterns.",
+  },
+]
+
+const exportSteps = [
+  {
+    title: "Request your data",
+    description: "Open Spotify Account Privacy and request Extended Streaming History for the fullest analysis.",
+  },
+  {
+    title: "Download and unzip",
+    description: "When Spotify sends the archive, download it and unzip the folder on your device.",
+  },
+  {
+    title: "Choose the history files",
+    description: "Select all Streaming_History_Audio_*.json files, or choose the entire unzipped Account Data folder.",
+  },
+  {
+    title: "Explore locally",
+    description: "The browser keeps only safe listening fields in memory and builds your dashboard in this tab.",
+  },
+]
+
+const faqs = [
+  {
+    question: "Does my Spotify data get uploaded?",
+    answer:
+      "No. JSON parsing and analysis happen inside this browser tab. There is no file-upload API, account connection, or server-side storage.",
+  },
+  {
+    question: "Which export should I use?",
+    answer:
+      "Extended Streaming History is recommended because it covers the lifetime of your account and includes album, platform, skip, shuffle, and offline fields. Standard music history is supported as a smaller fallback.",
+  },
+  {
+    question: "Should I select Technical Log Information?",
+    answer:
+      "No. Technical logs contain device, network, authentication, and diagnostic events, not the listening history needed here. The folder picker automatically skips them when possible.",
+  },
+  {
+    question: "Why are plays marked 30s+?",
+    answer:
+      "The dashboard uses a transparent 30-second threshold for its qualified-play rankings. Total listening hours still include every music listening event in the import.",
+  },
+]
+
+export default function SpotifyPage() {
+  return (
+    <div className="dark min-h-screen bg-zinc-950 text-white">
+      <PlaybackHeader activePlatform="spotify" guideHref="#how-to-export" />
+
+      <main id="main-content">
+        <SpotifyAnalyzer />
+
+        <section className="border-b border-white/[0.07] py-20 sm:py-24" aria-labelledby="discover-title">
+          <div className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+            <div className="max-w-2xl">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[#4ade80]">Inside your history</p>
+              <h2 id="discover-title" className="mt-4 text-3xl font-bold tracking-tight sm:text-4xl">
+                More than a top-ten list
+              </h2>
+              <p className="mt-4 text-base leading-7 text-zinc-400">
+                Spotify&apos;s export is a timeline. This analyzer turns it into context you can scan, compare, and understand.
+              </p>
+            </div>
+
+            <div className="mt-10 grid gap-4 sm:grid-cols-2">
+              {discoveries.map((item) => {
+                const Icon = item.icon
+                return (
+                  <Card key={item.title} className="border-white/10 bg-white/[0.035] text-white">
+                    <CardHeader className="pb-3">
+                      <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#1DB954]/[0.12] text-[#4ade80]">
+                        <Icon className="h-5 w-5" aria-hidden="true" />
+                      </span>
+                      <CardTitle className="pt-4 text-lg">{item.title}</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                      <p className="text-sm leading-6 text-zinc-400">{item.description}</p>
+                    </CardContent>
+                  </Card>
+                )
+              })}
+            </div>
+          </div>
+        </section>
+
+        <section id="how-to-export" className="scroll-mt-20 border-b border-white/[0.07] py-20 sm:py-24">
+          <div className="mx-auto grid w-full max-w-7xl gap-12 px-4 sm:px-6 lg:grid-cols-[0.8fr_1.2fr] lg:px-8">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[#4ade80]">Bring your own data</p>
+              <h2 className="mt-4 text-3xl font-bold tracking-tight sm:text-4xl">How to export Spotify history</h2>
+              <p className="mt-5 text-base leading-7 text-zinc-400">
+                Extended Streaming History covers the lifetime of your account. Spotify prepares it separately from the smaller account-data package.
+              </p>
+              <div className="mt-7 flex flex-col gap-3 sm:flex-row lg:flex-col lg:items-start">
+                <Button asChild className="bg-[#1DB954] font-semibold text-zinc-950 hover:bg-[#1ed760]">
+                  <Link href="https://www.spotify.com/account/privacy/" target="_blank" rel="noopener noreferrer">
+                    Open Spotify Account Privacy
+                    <ArrowUpRight className="ml-2 h-4 w-4" aria-hidden="true" />
+                  </Link>
+                </Button>
+                <Link
+                  href="https://support.spotify.com/article/understanding-your-data/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center text-sm text-zinc-400 underline-offset-4 hover:text-white hover:underline"
+                >
+                  Read Spotify&apos;s data guide
+                  <ArrowUpRight className="ml-1.5 h-3.5 w-3.5" aria-hidden="true" />
+                </Link>
+              </div>
+            </div>
+
+            <ol className="grid gap-3 sm:grid-cols-2">
+              {exportSteps.map((step, index) => (
+                <li key={step.title} className="rounded-2xl border border-white/10 bg-white/[0.03] p-5">
+                  <span className="font-mono text-xs font-semibold text-[#4ade80]">0{index + 1}</span>
+                  <h3 className="mt-4 font-semibold text-white">{step.title}</h3>
+                  <p className="mt-2 text-sm leading-6 text-zinc-400">{step.description}</p>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </section>
+
+        <section className="border-b border-white/[0.07] py-20 sm:py-24" aria-labelledby="privacy-title">
+          <div className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+            <div className="grid overflow-hidden rounded-3xl border border-[#1DB954]/20 bg-gradient-to-br from-[#1DB954]/[0.12] via-white/[0.03] to-transparent lg:grid-cols-[1fr_0.9fr]">
+              <div className="p-7 sm:p-10">
+                <ShieldCheck className="h-7 w-7 text-[#4ade80]" aria-hidden="true" />
+                <h2 id="privacy-title" className="mt-6 text-2xl font-bold tracking-tight sm:text-3xl">
+                  Personal data should stay personal
+                </h2>
+                <p className="mt-4 max-w-xl text-sm leading-7 text-zinc-300">
+                  The parser allowlists only listening fields. It never keeps IP addresses, usernames, country codes, search queries, user agents, or technical-log payloads.
+                </p>
+              </div>
+              <div className="grid gap-px border-t border-white/10 bg-white/10 sm:grid-cols-3 lg:grid-cols-1 lg:border-l lg:border-t-0">
+                {[
+                  ["Browser only", "No upload endpoint"],
+                  ["Memory only", "Refresh to clear"],
+                  ["Open source", "Inspect every rule"],
+                ].map(([title, detail]) => (
+                  <div key={title} className="bg-zinc-950/85 p-5 sm:p-6">
+                    <p className="text-sm font-semibold text-white">{title}</p>
+                    <p className="mt-1 text-xs text-zinc-500">{detail}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-20 sm:py-24" aria-labelledby="spotify-faq-title">
+          <div className="mx-auto w-full max-w-4xl px-4 sm:px-6 lg:px-8">
+            <div className="text-center">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[#4ade80]">Good to know</p>
+              <h2 id="spotify-faq-title" className="mt-4 text-3xl font-bold tracking-tight sm:text-4xl">
+                Before you analyze
+              </h2>
+            </div>
+            <div className="mt-10 space-y-3">
+              {faqs.map((faq) => (
+                <Card key={faq.question} className="border-white/10 bg-white/[0.03] text-white">
+                  <CardContent className="p-5 sm:p-6">
+                    <h3 className="font-semibold">{faq.question}</h3>
+                    <p className="mt-2 text-sm leading-6 text-zinc-400">{faq.answer}</p>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <PlaybackFooter />
+    </div>
+  )
+}

--- a/app/spotify/page.tsx
+++ b/app/spotify/page.tsx
@@ -16,7 +16,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 
 export const metadata: Metadata = {
-  title: "Spotify History Analyzer | Private Listening Stats",
+  title: "Spotify Listening History Analyzer & Stats | Playback Stats",
   description:
     "Analyze your Spotify streaming history locally. Explore listening time, top artists, tracks, trends, and playback habits without uploading your data.",
   alternates: {
@@ -26,13 +26,13 @@ export const metadata: Metadata = {
     type: "website",
     url: "https://playbackstats.com/spotify",
     siteName: "Playback Stats",
-    title: "Spotify History Analyzer | Private Listening Stats",
+    title: "Spotify Listening History Analyzer & Stats | Playback Stats",
     description:
       "Turn your Spotify streaming history into private charts and personal listening insights — all in your browser.",
   },
   twitter: {
     card: "summary_large_image",
-    title: "Spotify History Analyzer | Private Listening Stats",
+    title: "Spotify Listening History Analyzer & Stats | Playback Stats",
     description: "Private, local Spotify listening analysis with charts, rankings, and personal insights.",
   },
   robots: {
@@ -61,6 +61,24 @@ const discoveries = [
     icon: HeartPulse,
     title: "How you listen",
     description: "Extended exports reveal skip, shuffle, offline, platform, and natural-ending patterns.",
+  },
+]
+
+const analysisDetails = [
+  {
+    title: "Listening time and trends",
+    description:
+      "Sum Spotify's ms_played values into total hours, active days, monthly and yearly timelines, weekdays, and hours of the day.",
+  },
+  {
+    title: "Artists, tracks, and repeats",
+    description:
+      "Rank artists by listening time and tracks by qualified plays, while showing variety, repeat behavior, and each top artist's share.",
+  },
+  {
+    title: "Extended-history behavior",
+    description:
+      "When those fields exist, compare platform use, skips, shuffle listening, offline playback, and tracks played to their natural end.",
   },
 ]
 
@@ -104,6 +122,16 @@ const faqs = [
     answer:
       "The dashboard uses a transparent 30-second threshold for its qualified-play rankings. Total listening hours still include every music listening event in the import.",
   },
+  {
+    question: "Are podcasts and audiobooks included?",
+    answer:
+      "No. This is a music-history analyzer. Podcast episodes and audiobook chapters use different fields in Spotify exports, so the parser excludes them instead of mixing spoken audio into artist and track rankings.",
+  },
+  {
+    question: "What if I import both standard and extended history?",
+    answer:
+      "The analyzer prefers the richer extended records and omits standard-history records that fall inside the same covered date range. Standard records outside that range can still extend the timeline.",
+  },
 ]
 
 export default function SpotifyPage() {
@@ -119,10 +147,10 @@ export default function SpotifyPage() {
             <div className="max-w-2xl">
               <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[#4ade80]">Inside your history</p>
               <h2 id="discover-title" className="mt-4 text-3xl font-bold tracking-tight sm:text-4xl">
-                More than a top-ten list
+                Spotify listening stats, with context
               </h2>
               <p className="mt-4 text-base leading-7 text-zinc-400">
-                Spotify&apos;s export is a timeline. This analyzer turns it into context you can scan, compare, and understand.
+                Spotify&apos;s streaming-history export is a timeline of playback events. This analyzer turns those records into listening patterns you can scan, compare, and understand.
               </p>
             </div>
 
@@ -144,6 +172,34 @@ export default function SpotifyPage() {
                 )
               })}
             </div>
+
+            <article
+              aria-labelledby="spotify-analysis-method-title"
+              className="mt-4 rounded-3xl border border-white/10 bg-zinc-950/70 p-6 sm:p-8"
+            >
+              <div className="max-w-3xl">
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[#4ade80]">How the analysis works</p>
+                <h3 id="spotify-analysis-method-title" className="mt-4 text-2xl font-bold tracking-tight sm:text-3xl">
+                  What this Spotify history analyzer calculates
+                </h3>
+                <p className="mt-4 text-sm leading-7 text-zinc-400 sm:text-base">
+                  Playback Stats reads recognized music records from Standard Streaming History or Extended Streaming History. It uses Spotify&apos;s own timestamps and milliseconds played, keeps the analysis in memory, and separates total listening time from qualified plays of at least 30 seconds.
+                </p>
+              </div>
+
+              <dl className="mt-8 grid gap-3 md:grid-cols-3">
+                {analysisDetails.map((item) => (
+                  <div key={item.title} className="rounded-2xl bg-white/[0.04] p-5 ring-1 ring-inset ring-white/[0.06]">
+                    <dt className="font-semibold text-white">{item.title}</dt>
+                    <dd className="mt-2 text-sm leading-6 text-zinc-400">{item.description}</dd>
+                  </div>
+                ))}
+              </dl>
+
+              <p className="mt-4 rounded-2xl border border-[#1DB954]/15 bg-[#1DB954]/[0.06] p-5 text-sm leading-6 text-zinc-400">
+                Podcast episodes and audiobook chapters are intentionally excluded so music rankings stay comparable. Behavior metrics appear only when the selected export actually contains those extended fields.
+              </p>
+            </article>
           </div>
         </section>
 
@@ -219,7 +275,7 @@ export default function SpotifyPage() {
             <div className="text-center">
               <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[#4ade80]">Good to know</p>
               <h2 id="spotify-faq-title" className="mt-4 text-3xl font-bold tracking-tight sm:text-4xl">
-                Before you analyze
+                Spotify listening history analyzer FAQ
               </h2>
             </div>
             <div className="mt-10 space-y-3">

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,20 +1,20 @@
 import Link from "next/link"
-import { ArrowLeft } from "lucide-react"
 import { Metadata } from "next"
 
-import { Button } from "@/components/ui/button"
+import PlaybackFooter from "@/components/playback-footer"
+import PlaybackHeader from "@/components/playback-header"
 
 export const metadata: Metadata = {
-  title: "Terms of Service | YouTube History Visualizer",
-  description: "Terms of service and usage conditions for the YouTube History Visualizer tool.",
+  title: "Terms of Service | Playback Stats",
+  description: "Terms of service and usage conditions for Playback Stats.",
   openGraph: {
-    title: "Terms of Service | YouTube History Visualizer",
-    description: "Terms of service and usage conditions for the YouTube History Visualizer tool.",
+    title: "Terms of Service | Playback Stats",
+    description: "Terms of service and usage conditions for Playback Stats.",
     url: "https://playbackstats.com/terms",
   },
   twitter: {
-    title: "Terms of Service | YouTube History Visualizer",
-    description: "Terms of service and usage conditions for the YouTube History Visualizer tool.",
+    title: "Terms of Service | Playback Stats",
+    description: "Terms of service and usage conditions for Playback Stats.",
   },
   alternates: {
     canonical: "https://playbackstats.com/terms",
@@ -23,33 +23,21 @@ export const metadata: Metadata = {
 
 export default function TermsOfService() {
   return (
-    <div className="flex flex-col min-h-screen">
-      <header className="border-b">
-        <div className="container mx-auto flex h-16 items-center px-4 sm:px-6 lg:px-8">
-          <Link href="/" className="flex items-center gap-2">
-            <h1 className="text-lg font-semibold">YouTube History Visualizer</h1>
-          </Link>
-          <nav className="ml-auto flex gap-4">
-            <Button variant="ghost" size="sm" asChild>
-              <Link href="/" className="flex items-center gap-1">
-                <ArrowLeft className="h-4 w-4" /> Back to Home
-              </Link>
-            </Button>
-          </nav>
-        </div>
-      </header>
-      <main className="flex-1">
-        <div className="container mx-auto py-12 px-4 md:px-6">
-          <div className="max-w-3xl mx-auto space-y-8">
+    <div className="dark flex min-h-screen flex-col bg-zinc-950 text-white">
+      <PlaybackHeader />
+      <main id="main-content" className="flex-1">
+        <div className="mx-auto w-full max-w-7xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
+          <article className="mx-auto max-w-3xl space-y-10 text-sm leading-7 text-zinc-300 [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:tracking-tight [&_h2]:text-white [&_li]:pl-1 [&_strong]:font-semibold [&_strong]:text-white sm:text-base">
             <div>
-              <h1 className="text-3xl font-bold tracking-tighter sm:text-4xl md:text-5xl mb-4">Terms of Service</h1>
-              <p className="text-gray-500">Last Updated: {new Date().toLocaleDateString()}</p>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-500">Playback Stats</p>
+              <h1 className="mt-4 text-4xl font-bold tracking-[-0.04em] text-white sm:text-5xl">Terms of Service</h1>
+              <p className="mt-4 text-sm text-zinc-500">Last updated: {new Date().toLocaleDateString()}</p>
             </div>
 
             <section className="space-y-4">
               <h2 className="text-2xl font-bold">1. Introduction</h2>
               <p>
-                Welcome to YouTube History Visualizer. By accessing or using our website, you agree to be bound by
+                Welcome to Playback Stats. By accessing or using our website, you agree to be bound by
                 these Terms of Service. If you do not agree to these terms, please do not use our service.
               </p>
             </section>
@@ -57,9 +45,8 @@ export default function TermsOfService() {
             <section className="space-y-4">
               <h2 className="text-2xl font-bold">2. Description of Service</h2>
               <p>
-                YouTube History Visualizer provides a tool for users to visualize their YouTube watch history data.
-                The service processes the data locally in the user&apos;s browser to generate visualizations and
-                insights about their YouTube viewing habits.
+                Playback Stats provides tools for users to visualize supported YouTube and Spotify history data. The
+                service processes history files locally in the user&apos;s browser to generate visualizations and insights.
               </p>
             </section>
 
@@ -67,7 +54,7 @@ export default function TermsOfService() {
               <h2 className="text-2xl font-bold">3. User Responsibilities</h2>
               <p>By using our service, you agree to:</p>
               <ul className="list-disc pl-6 space-y-2">
-                <li>Provide your own YouTube history data for processing</li>
+                <li>Provide only history data that you are authorized to process</li>
                 <li>Use the service only for personal, non-commercial purposes</li>
                 <li>Not attempt to reverse engineer, modify, or manipulate the service</li>
                 <li>Not use the service to violate any laws or regulations</li>
@@ -81,9 +68,8 @@ export default function TermsOfService() {
             <section className="space-y-4">
               <h2 className="text-2xl font-bold">4. Intellectual Property</h2>
               <p>
-                All content, features, and functionality of YouTube History Visualizer, including but not limited to
-                text, graphics, logos, icons, and software code, are the exclusive property of YouTube History
-                Visualizer and are protected by copyright, trademark, and other intellectual property laws.
+                All content, features, and functionality of Playback Stats are subject to applicable copyright,
+                trademark, open-source licenses, and other intellectual property laws.
               </p>
               <p>
                 You are granted a limited, non-exclusive, non-transferable license to use the service for personal,
@@ -94,7 +80,7 @@ export default function TermsOfService() {
             <section className="space-y-4">
               <h2 className="text-2xl font-bold">5. Disclaimer of Warranties</h2>
               <p>
-                YouTube History Visualizer is provided &quot;as is&quot; and &quot;as available&quot; without any
+                Playback Stats is provided &quot;as is&quot; and &quot;as available&quot; without any
                 warranties of any kind, either express or implied. We do not guarantee that:
               </p>
               <ul className="list-disc pl-6 space-y-2">
@@ -108,7 +94,7 @@ export default function TermsOfService() {
             <section className="space-y-4">
               <h2 className="text-2xl font-bold">6. Limitation of Liability</h2>
               <p>
-                In no event shall YouTube History Visualizer, its directors, employees, partners, agents, suppliers, or
+                In no event shall Playback Stats, its directors, employees, partners, agents, suppliers, or
                 affiliates be liable for any indirect, incidental, special, consequential, or punitive damages,
                 including without limitation, loss of profits, data, use, goodwill, or other intangible losses,
                 resulting from:
@@ -124,9 +110,9 @@ export default function TermsOfService() {
             <section className="space-y-4">
               <h2 className="text-2xl font-bold">7. Data Usage and Privacy</h2>
               <p>
-                We process your YouTube history data entirely in your browser. We do not collect, store, or transmit
-                any of your personal data. For more information, please refer to our{" "}
-                <Link href="/privacy" className="text-primary hover:underline">
+                We process supported history files entirely in your browser and do not collect, store, or transmit
+                their contents or generated insights. Limited aggregate site analytics are described in our{" "}
+                <Link href="/privacy" className="font-medium text-white underline decoration-white/30 underline-offset-4 hover:decoration-white">
                   Privacy Policy
                 </Link>
                 .
@@ -166,24 +152,10 @@ export default function TermsOfService() {
                 support@playbackstats.com
               </p>
             </section>
-          </div>
+          </article>
         </div>
       </main>
-      <footer className="border-t py-6">
-        <div className="container mx-auto flex flex-col md:flex-row items-center justify-between px-4 sm:px-6 lg:px-8">
-          <p className="text-center text-sm leading-loose text-gray-500 md:text-left">
-            © {new Date().getFullYear()} YouTube History Visualizer. All rights reserved.
-          </p>
-          <div className="flex items-center gap-4">
-            <Link href="/privacy" className="text-sm text-gray-500 hover:underline">
-              Privacy Policy
-            </Link>
-            <Link href="/terms" className="text-sm text-gray-500 hover:underline">
-              Terms of Service
-            </Link>
-          </div>
-        </div>
-      </footer>
+      <PlaybackFooter />
     </div>
   )
-} 
+}

--- a/components/file-upload-form.tsx
+++ b/components/file-upload-form.tsx
@@ -4,7 +4,7 @@ import type React from "react"
 
 import { useState, useRef } from "react"
 import { useRouter } from "next/navigation"
-import { Upload, X, FileJson, CheckCircle2, Loader2 } from "lucide-react"
+import { Upload, X, FileJson, CheckCircle2, Loader2, ShieldCheck } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
@@ -274,7 +274,7 @@ export default function FileUploadForm() {
             const dateString = date.toISOString().split("T")[0] // YYYY-MM-DD format
             dateMap.set(dateString, (dateMap.get(dateString) || 0) + 1)
           }
-        } catch (e) {
+        } catch {
           // Skip invalid dates
         }
       }
@@ -293,7 +293,7 @@ export default function FileUploadForm() {
             const hour = date.getHours()
             hourCounts[hour].count += 1
           }
-        } catch (e) {
+        } catch {
           // Skip invalid dates
         }
       }
@@ -580,7 +580,7 @@ export default function FileUploadForm() {
       }
 
       reader.readAsText(file)
-    } catch (error) {
+    } catch {
       setError("An unexpected error occurred")
       setIsProcessing(false)
     }
@@ -589,18 +589,18 @@ export default function FileUploadForm() {
   return (
     <div className="w-full">
       {error && (
-        <div className="mb-4 p-4 bg-destructive/10 border border-destructive/20 text-destructive rounded-xl text-sm animate-scale-in flex items-center gap-3">
-          <div className="w-2 h-2 rounded-full bg-destructive animate-pulse" />
+        <div className="mb-4 flex items-center gap-3 rounded-2xl border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-200 animate-scale-in">
+          <div className="h-2 w-2 rounded-full bg-red-400" />
           {error}
         </div>
       )}
 
       {!file ? (
         <div
-          className={`upload-zone relative border-2 border-dashed rounded-2xl p-10 text-center transition-all duration-300 cursor-pointer group
+          className={`group relative cursor-pointer rounded-3xl border border-dashed p-7 text-center transition-all duration-300 sm:p-8
             ${isDragging 
-              ? "dragging border-primary bg-primary/5 scale-[1.02]" 
-              : "border-muted-foreground/25 hover:border-primary/50 hover:bg-muted/50"
+              ? "scale-[1.01] border-red-400 bg-red-500/10"
+              : "border-white/15 bg-white/[0.04] hover:border-white/25 hover:bg-white/[0.06]"
             }`}
           onDragOver={handleDragOver}
           onDragLeave={handleDragLeave}
@@ -608,33 +608,31 @@ export default function FileUploadForm() {
           onClick={() => fileInputRef.current?.click()}
         >
           <div className="flex flex-col items-center justify-center space-y-4">
-            <div className={`relative p-4 rounded-2xl transition-all duration-300
+            <div className={`relative flex h-16 w-16 items-center justify-center rounded-2xl ring-1 ring-inset transition-all duration-300
               ${isDragging 
-                ? "bg-primary/20 scale-110" 
-                : "bg-muted group-hover:bg-primary/10"
+                ? "scale-105 bg-red-500/20 text-red-200 ring-red-400/35"
+                : "bg-red-500/15 text-red-300 ring-red-500/25"
               }`}>
-              <Upload className={`h-10 w-10 transition-all duration-300
-                ${isDragging 
-                  ? "text-primary" 
-                  : "text-muted-foreground group-hover:text-primary"
-                }`} />
-              {isDragging && (
-                <div className="absolute inset-0 rounded-2xl animate-ping bg-primary/20" />
-              )}
+              <Upload className="h-8 w-8 transition-transform duration-300 group-hover:-translate-y-0.5" />
             </div>
             
             <div className="space-y-2">
-              <h3 className="text-lg font-semibold">
-                {isDragging ? "Drop it here!" : "Drop your file here"}
-              </h3>
-              <p className="text-sm text-muted-foreground">
-                or <span className="text-primary font-medium hover:underline">browse</span> to upload
+              <h2 className="text-xl font-semibold text-white">
+                {isDragging ? "Drop it here" : "Bring your YouTube history"}
+              </h2>
+              <p className="text-sm leading-6 text-zinc-400">
+                Drop the JSON file here, or <span className="font-medium text-red-300 group-hover:text-red-200">choose a file</span>
               </p>
             </div>
-            
-            <div className="flex items-center gap-2 px-4 py-2 rounded-full bg-muted/50 text-xs text-muted-foreground">
-              <FileJson className="h-3.5 w-3.5" />
-              watch-history.json (Max 100MB)
+
+            <div className="flex items-center gap-2 rounded-xl border border-white/[0.08] bg-black/20 px-3 py-2 text-xs text-zinc-500">
+              <FileJson className="h-3.5 w-3.5 text-red-300" />
+              watch-history.json · up to 100 MB
+            </div>
+
+            <div className="flex items-center gap-2 text-xs text-zinc-500">
+              <ShieldCheck className="h-3.5 w-3.5 text-red-300" aria-hidden="true" />
+              The file stays in this browser tab
             </div>
           </div>
           
@@ -648,18 +646,18 @@ export default function FileUploadForm() {
           />
         </div>
       ) : (
-        <Card className="p-5 animate-scale-in bg-card/50 backdrop-blur border-primary/20">
+        <Card className="animate-scale-in border-white/10 bg-zinc-900/80 p-5 text-white shadow-2xl shadow-black/20">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-4">
-              <div className="relative p-3 bg-primary/10 rounded-xl">
-                <FileJson className="h-6 w-6 text-primary" />
+              <div className="relative rounded-xl bg-red-500/15 p-3">
+                <FileJson className="h-6 w-6 text-red-300" />
                 {!isProcessing && (
-                  <div className="absolute -top-1 -right-1 w-3 h-3 bg-green-500 rounded-full border-2 border-card" />
+                  <div className="absolute -right-1 -top-1 h-3 w-3 rounded-full border-2 border-zinc-900 bg-emerald-400" />
                 )}
               </div>
               <div>
                 <p className="font-semibold">{file.name}</p>
-                <p className="text-sm text-muted-foreground">
+                <p className="text-sm text-zinc-400">
                   {(file.size / (1024 * 1024)).toFixed(2)} MB
                 </p>
               </div>
@@ -669,7 +667,7 @@ export default function FileUploadForm() {
               size="icon" 
               onClick={removeFile} 
               disabled={isProcessing}
-              className="rounded-full hover:bg-destructive/10 hover:text-destructive"
+              className="rounded-full text-zinc-400 hover:bg-white/10 hover:text-white"
             >
               <X className="h-4 w-4" />
               <span className="sr-only">Remove file</span>
@@ -678,29 +676,29 @@ export default function FileUploadForm() {
 
           {isProcessing && (
             <div className="mt-5 space-y-3 animate-fade-in">
-              <div className="relative h-3 bg-muted rounded-full overflow-hidden">
+              <div className="relative h-2 overflow-hidden rounded-full bg-white/10">
                 <div 
-                  className="absolute inset-y-0 left-0 bg-gradient-to-r from-primary via-primary to-orange-500 rounded-full transition-all duration-300 ease-out progress-animated"
+                  className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-red-600 to-red-300 transition-all duration-300 ease-out"
                   style={{ width: `${progress}%` }}
                 />
               </div>
               <div className="flex items-center justify-between text-sm">
-                <div className="flex items-center gap-2 text-muted-foreground">
+                <div className="flex items-center gap-2 text-zinc-400">
                   {progress < 100 ? (
-                    <Loader2 className="h-4 w-4 animate-spin text-primary" />
+                    <Loader2 className="h-4 w-4 animate-spin text-red-300" />
                   ) : (
-                    <CheckCircle2 className="h-4 w-4 text-green-500" />
+                    <CheckCircle2 className="h-4 w-4 text-emerald-400" />
                   )}
                   {progressStage}
                 </div>
-                <span className="font-mono text-primary font-semibold">{progress}%</span>
+                <span className="font-mono font-semibold text-red-300">{progress}%</span>
               </div>
             </div>
           )}
 
           {!isProcessing && (
             <Button 
-              className="w-full mt-5 h-12 text-base font-semibold bg-gradient-to-r from-primary to-orange-500 hover:from-primary/90 hover:to-orange-500/90 transition-all duration-300 hover:scale-[1.02] active:scale-[0.98]" 
+              className="mt-5 h-12 w-full bg-red-500 text-base font-semibold text-white transition-all duration-200 hover:bg-red-400 active:scale-[0.99]"
               onClick={processFile}
             >
               <span className="flex items-center gap-2">

--- a/components/playback-footer.tsx
+++ b/components/playback-footer.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link"
+import { HardDrive } from "lucide-react"
+
+export default function PlaybackFooter() {
+  return (
+    <footer className="border-t border-white/[0.08] bg-zinc-950 py-8">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-4 text-sm text-zinc-500 sm:px-6 md:flex-row md:items-center md:justify-between lg:px-8">
+        <div className="flex items-center gap-2">
+          <HardDrive className="h-4 w-4 text-zinc-300" aria-hidden="true" />
+          <span>Your history stays on your device · {new Date().getFullYear()}</span>
+        </div>
+        <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
+          <Link href="/" className="transition-colors hover:text-white">YouTube</Link>
+          <Link href="/spotify" className="transition-colors hover:text-white">Spotify</Link>
+          <Link href="/privacy" className="transition-colors hover:text-white">Privacy</Link>
+          <Link href="/terms" className="transition-colors hover:text-white">Terms</Link>
+          <Link
+            href="https://github.com/ronething/yt-history"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="transition-colors hover:text-white"
+          >
+            GitHub
+          </Link>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/components/playback-header.tsx
+++ b/components/playback-header.tsx
@@ -1,0 +1,91 @@
+import Link from "next/link"
+import { Github, Music2, Youtube } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+type Platform = "youtube" | "spotify"
+
+interface PlaybackHeaderProps {
+  activePlatform?: Platform
+  guideHref?: string
+}
+
+const platformLinks = [
+  {
+    id: "youtube" as const,
+    href: "/",
+    label: "YouTube",
+    icon: Youtube,
+    activeClass: "border-red-500/25 bg-red-500/15 text-red-200",
+  },
+  {
+    id: "spotify" as const,
+    href: "/spotify",
+    label: "Spotify",
+    icon: Music2,
+    activeClass: "border-emerald-400/25 bg-emerald-400/15 text-emerald-200",
+  },
+]
+
+export default function PlaybackHeader({ activePlatform, guideHref }: PlaybackHeaderProps) {
+  return (
+    <header className="sticky top-0 z-50 border-b border-white/[0.08] bg-zinc-950/85 backdrop-blur-xl">
+      <div className="mx-auto flex h-16 w-full max-w-7xl items-center gap-3 px-4 sm:px-6 lg:px-8">
+        <Link href="/" className="group flex min-w-0 items-center gap-2.5" aria-label="Playback Stats home">
+          <span className="relative flex h-8 w-8 shrink-0 items-end justify-center gap-[3px] overflow-hidden rounded-xl border border-white/10 bg-white/[0.06] pb-2 shadow-inner shadow-white/5 transition-colors group-hover:bg-white/[0.1]">
+            <span className="h-2 w-[3px] rounded-full bg-white/45" />
+            <span className="h-4 w-[3px] rounded-full bg-white" />
+            <span className="h-3 w-[3px] rounded-full bg-white/65" />
+          </span>
+          <span className="hidden truncate text-sm font-semibold tracking-[-0.02em] text-white min-[430px]:inline sm:text-base">
+            Playback Stats
+          </span>
+        </Link>
+
+        <nav className="ml-auto flex min-w-0 items-center gap-2 sm:gap-3" aria-label="Playback Stats navigation">
+          <div className="flex items-center rounded-xl border border-white/[0.08] bg-white/[0.035] p-1">
+            {platformLinks.map((platform) => {
+              const Icon = platform.icon
+              const isActive = activePlatform === platform.id
+
+              return (
+                <Link
+                  key={platform.id}
+                  href={platform.href}
+                  aria-current={isActive ? "page" : undefined}
+                  className={cn(
+                    "flex h-8 items-center gap-1.5 rounded-lg border border-transparent px-2 text-xs font-medium text-zinc-400 transition-all duration-200 hover:bg-white/[0.06] hover:text-white active:scale-[0.98] sm:px-3",
+                    isActive && platform.activeClass,
+                  )}
+                >
+                  <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+                  <span className="hidden sm:inline">{platform.label}</span>
+                  <span className="sr-only sm:hidden">{platform.label}</span>
+                </Link>
+              )
+            })}
+          </div>
+
+          {guideHref && (
+            <Link
+              href={guideHref}
+              className="hidden text-sm font-medium text-zinc-400 transition-colors hover:text-white lg:block"
+            >
+              Export guide
+            </Link>
+          )}
+
+          <Link
+            href="https://github.com/ronething/yt-history"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hidden rounded-xl p-2 text-zinc-400 transition-colors hover:bg-white/[0.07] hover:text-white md:block"
+            aria-label="View Playback Stats on GitHub"
+          >
+            <Github className="h-4 w-4" aria-hidden="true" />
+          </Link>
+        </nav>
+      </div>
+    </header>
+  )
+}

--- a/components/promo-banner.tsx
+++ b/components/promo-banner.tsx
@@ -5,7 +5,7 @@ const MUSIC_GENERATOR_URL = "https://music-generator.net/"
 
 export default function PromoBanner() {
   return (
-    <div className="w-full border-b border-cyan-400/20 bg-zinc-950 text-white">
+    <div className="w-full border-b border-white/[0.08] bg-zinc-950 text-white">
       <Link
         href={MUSIC_GENERATOR_URL}
         target="_blank"
@@ -13,7 +13,7 @@ export default function PromoBanner() {
         className="group mx-auto flex min-h-12 max-w-7xl flex-wrap items-center justify-center gap-x-2 gap-y-1 px-4 py-2 text-center text-sm transition-colors hover:bg-white/[0.04] sm:min-h-10 sm:gap-x-3 sm:text-left"
         aria-label="Create AI music and background tracks with Musefy"
       >
-        <span className="inline-flex items-center gap-1.5 font-semibold text-cyan-200">
+        <span className="inline-flex items-center gap-1.5 font-semibold text-zinc-100">
           <Music2 className="h-4 w-4" aria-hidden="true" />
           AI music for creators
         </span>

--- a/components/spotify/spotify-analyzer.tsx
+++ b/components/spotify/spotify-analyzer.tsx
@@ -8,7 +8,7 @@ import SpotifyUpload from "@/components/spotify/spotify-upload"
 import type { SpotifyAnalysis } from "@/lib/spotify-analysis"
 
 const promises = [
-  { icon: BarChart3, label: "7+ years", detail: "Trend lines and yearly chapters" },
+  { icon: BarChart3, label: "Your timeline", detail: "Monthly and yearly listening trends" },
   { icon: Music2, label: "Your favorites", detail: "Artists and tracks ranked clearly" },
   { icon: Clock3, label: "Your rhythm", detail: "Hours, weekdays, and streaks" },
 ]
@@ -54,13 +54,13 @@ export default function SpotifyAnalyzer() {
           </div>
 
           <h1 className="mt-7 text-balance text-4xl font-bold tracking-[-0.04em] text-white sm:text-5xl lg:text-6xl">
-            See the story behind your{" "}
+            Analyze your{" "}
             <span className="bg-gradient-to-r from-[#1ed760] via-emerald-300 to-[#1DB954] bg-clip-text text-transparent">
-              Spotify listening
+              Spotify listening history
             </span>
           </h1>
           <p className="mt-6 max-w-xl text-base leading-7 text-zinc-400 sm:text-lg sm:leading-8">
-            Turn your Spotify streaming history into a private, interactive look at the music, people, and patterns that shaped your time.
+            Import Spotify streaming-history JSON files to explore listening time, top artists and tracks, monthly trends, streaks, and playback habits in a private dashboard.
           </p>
 
           <div className="mt-9 grid gap-3 sm:grid-cols-3">

--- a/components/spotify/spotify-analyzer.tsx
+++ b/components/spotify/spotify-analyzer.tsx
@@ -1,0 +1,96 @@
+"use client"
+
+import { useState } from "react"
+import { BarChart3, Clock3, Music2, ShieldCheck, Sparkles } from "lucide-react"
+
+import SpotifyDashboard from "@/components/spotify/spotify-dashboard"
+import SpotifyUpload from "@/components/spotify/spotify-upload"
+import type { SpotifyAnalysis } from "@/lib/spotify-analysis"
+
+const promises = [
+  { icon: BarChart3, label: "7+ years", detail: "Trend lines and yearly chapters" },
+  { icon: Music2, label: "Your favorites", detail: "Artists and tracks ranked clearly" },
+  { icon: Clock3, label: "Your rhythm", detail: "Hours, weekdays, and streaks" },
+]
+
+export default function SpotifyAnalyzer() {
+  const [analysis, setAnalysis] = useState<SpotifyAnalysis | null>(null)
+
+  const handleComplete = (nextAnalysis: SpotifyAnalysis) => {
+    setAnalysis(nextAnalysis)
+    window.setTimeout(() => {
+      document.getElementById("spotify-dashboard")?.scrollIntoView({ behavior: "smooth", block: "start" })
+    }, 50)
+  }
+
+  const handleReset = () => {
+    setAnalysis(null)
+    window.setTimeout(() => {
+      document.getElementById("spotify-upload")?.scrollIntoView({ behavior: "smooth", block: "start" })
+    }, 50)
+  }
+
+  if (analysis) {
+    return (
+      <section className="mx-auto w-full max-w-7xl px-4 pt-10 sm:px-6 lg:px-8">
+        <SpotifyDashboard analysis={analysis} onReset={handleReset} />
+      </section>
+    )
+  }
+
+  return (
+    <section id="spotify-upload" className="relative overflow-hidden border-b border-white/[0.07]">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute left-[-14rem] top-[-12rem] h-[32rem] w-[32rem] rounded-full bg-[#1DB954]/10 blur-[100px]" />
+        <div className="absolute right-[-12rem] top-[6rem] h-[30rem] w-[30rem] rounded-full bg-emerald-300/[0.06] blur-[110px]" />
+        <div className="absolute inset-0 bg-[linear-gradient(rgba(255,255,255,0.025)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.025)_1px,transparent_1px)] bg-[size:48px_48px] [mask-image:linear-gradient(to_bottom,black,transparent_80%)]" />
+      </div>
+
+      <div className="relative mx-auto grid min-h-[720px] w-full max-w-7xl items-center gap-12 px-4 py-16 sm:px-6 sm:py-20 lg:grid-cols-[1.02fr_0.98fr] lg:px-8 lg:py-24">
+        <div className="max-w-2xl">
+          <div className="inline-flex items-center gap-2 rounded-full border border-[#1DB954]/25 bg-[#1DB954]/10 px-3 py-1.5 text-xs font-medium text-[#4ade80]">
+            <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+            100% local — your files never leave this browser
+          </div>
+
+          <h1 className="mt-7 text-balance text-4xl font-bold tracking-[-0.04em] text-white sm:text-5xl lg:text-6xl">
+            See the story behind your{" "}
+            <span className="bg-gradient-to-r from-[#1ed760] via-emerald-300 to-[#1DB954] bg-clip-text text-transparent">
+              Spotify listening
+            </span>
+          </h1>
+          <p className="mt-6 max-w-xl text-base leading-7 text-zinc-400 sm:text-lg sm:leading-8">
+            Turn your Spotify streaming history into a private, interactive look at the music, people, and patterns that shaped your time.
+          </p>
+
+          <div className="mt-9 grid gap-3 sm:grid-cols-3">
+            {promises.map((item) => {
+              const Icon = item.icon
+              return (
+                <div key={item.label} className="rounded-2xl border border-white/[0.08] bg-white/[0.035] p-4 backdrop-blur">
+                  <Icon className="h-4 w-4 text-[#4ade80]" aria-hidden="true" />
+                  <p className="mt-4 text-sm font-semibold text-white">{item.label}</p>
+                  <p className="mt-1 text-xs leading-5 text-zinc-500">{item.detail}</p>
+                </div>
+              )
+            })}
+          </div>
+
+          <div className="mt-8 flex items-start gap-3 text-sm leading-6 text-zinc-500">
+            <Sparkles className="mt-1 h-4 w-4 shrink-0 text-[#4ade80]" aria-hidden="true" />
+            <p>
+              No Spotify login, API key, or server upload. Insights are generated deterministically in your tab — no AI sees your track history.
+            </p>
+          </div>
+        </div>
+
+        <div className="relative lg:pl-4">
+          <div className="absolute -inset-6 rounded-[2rem] bg-[#1DB954]/[0.1] blur-2xl" />
+          <div className="relative rounded-[2rem] border border-white/10 bg-zinc-950/70 p-3 shadow-2xl shadow-black/40 backdrop-blur-xl sm:p-5">
+            <SpotifyUpload onComplete={handleComplete} />
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/spotify/spotify-dashboard.tsx
+++ b/components/spotify/spotify-dashboard.tsx
@@ -1,0 +1,524 @@
+"use client"
+
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts"
+import {
+  CalendarDays,
+  CheckCircle2,
+  Clock3,
+  Database,
+  Disc3,
+  Headphones,
+  Info,
+  ListMusic,
+  Mic2,
+  Play,
+  Radio,
+  RotateCcw,
+  Shuffle,
+  SkipForward,
+  Sparkles,
+  WifiOff,
+} from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import type { SpotifyAnalysis } from "@/lib/spotify-analysis"
+
+interface SpotifyDashboardProps {
+  analysis: SpotifyAnalysis
+  onReset: () => void
+}
+
+const insightToneClasses: Record<SpotifyAnalysis["insights"][number]["tone"], string> = {
+  green: "border-emerald-400/20 bg-emerald-400/[0.07] text-emerald-200",
+  violet: "border-violet-400/20 bg-violet-400/[0.07] text-violet-200",
+  amber: "border-amber-400/20 bg-amber-400/[0.07] text-amber-200",
+  sky: "border-sky-400/20 bg-sky-400/[0.07] text-sky-200",
+}
+
+function formatNumber(value: number, maximumFractionDigits = 1): string {
+  return value.toLocaleString(undefined, { maximumFractionDigits })
+}
+
+function formatHours(hours: number): string {
+  if (hours < 1) return `${Math.round(hours * 60)} min`
+  return `${formatNumber(hours)} hr`
+}
+
+function formatPercentage(value: number | undefined): string {
+  if (value === undefined) return "—"
+  if (value > 0 && value < 0.1) return "<0.1%"
+  return `${formatNumber(value)}%`
+}
+
+function formatDate(timestamp: number): string {
+  return new Date(timestamp).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })
+}
+
+function formatMonth(month: string): string {
+  return new Date(`${month}-01T00:00:00`).toLocaleDateString(undefined, {
+    month: "short",
+    year: "2-digit",
+  })
+}
+
+function MonthlyTooltip({ active, payload, label }: any) {
+  if (!active || !payload?.length) return null
+  const item = payload[0]?.payload
+  return (
+    <div className="rounded-xl border border-white/10 bg-zinc-950/95 px-4 py-3 text-sm shadow-2xl backdrop-blur">
+      <p className="mb-2 font-medium text-white">{formatMonth(label)}</p>
+      <p className="text-[#4ade80]">{formatNumber(item.hours, 2)} listening hours</p>
+      <p className="mt-1 text-zinc-400">{item.plays.toLocaleString()} qualified plays</p>
+    </div>
+  )
+}
+
+function RhythmTooltip({ active, payload, label, unit, formatLabel = (value: unknown) => String(value) }: any) {
+  if (!active || !payload?.length) return null
+  return (
+    <div className="rounded-xl border border-white/10 bg-zinc-950/95 px-4 py-3 text-sm shadow-2xl backdrop-blur">
+      <p className="font-medium text-white">{formatLabel(label)}</p>
+      <p className="mt-1 text-[#4ade80]">
+        {formatNumber(Number(payload[0]?.value || 0))} {unit}
+      </p>
+    </div>
+  )
+}
+
+function ChartCard({
+  title,
+  description,
+  children,
+  className = "",
+}: {
+  title: string
+  description: string
+  children: React.ReactNode
+  className?: string
+}) {
+  return (
+    <Card className={`border-white/10 bg-white/[0.035] text-white shadow-xl shadow-black/10 ${className}`}>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-lg">{title}</CardTitle>
+        <p className="text-sm leading-6 text-zinc-400">{description}</p>
+      </CardHeader>
+      <CardContent>{children}</CardContent>
+    </Card>
+  )
+}
+
+function RankingRow({
+  rank,
+  title,
+  subtitle,
+  value,
+  percentage,
+}: {
+  rank: number
+  title: string
+  subtitle: string
+  value: string
+  percentage: number
+}) {
+  return (
+    <div className="group relative overflow-hidden rounded-2xl border border-white/[0.07] bg-white/[0.025] p-4 transition-colors hover:bg-white/[0.05]">
+      <div
+        className="absolute inset-y-0 left-0 bg-[#1DB954]/[0.08] transition-all group-hover:bg-[#1DB954]/[0.12]"
+        style={{ width: `${Math.max(2, percentage)}%` }}
+      />
+      <div className="relative flex items-center gap-3">
+        <span className="w-7 shrink-0 font-mono text-sm font-semibold text-[#4ade80]">{String(rank).padStart(2, "0")}</span>
+        <div className="min-w-0 flex-1">
+          <p className="truncate font-medium text-white" title={title}>{title}</p>
+          <p className="mt-1 truncate text-xs text-zinc-500" title={subtitle}>{subtitle}</p>
+        </div>
+        <span className="shrink-0 text-sm font-semibold text-zinc-200">{value}</span>
+      </div>
+    </div>
+  )
+}
+
+export default function SpotifyDashboard({ analysis, onReset }: SpotifyDashboardProps) {
+  const { summary, source, behavior } = analysis
+  const maxArtistHours = analysis.topArtists[0]?.hours || 1
+  const maxTrackPlays = Math.max(1, ...analysis.topTracks.map((track) => track.plays))
+  const monthTickInterval = Math.max(0, Math.ceil(analysis.monthly.length / 8) - 1)
+  const sourceLabel = source.format === "extended"
+    ? "Extended history"
+    : source.format === "mixed"
+      ? "Extended + newer standard history"
+      : "Standard history"
+
+  const statCards = [
+    {
+      label: "Listening time",
+      value: formatNumber(summary.totalHours),
+      suffix: "hours",
+      detail: `${formatNumber(summary.totalHours / 24)} days with music`,
+      icon: Headphones,
+    },
+    {
+      label: "Qualified plays",
+      value: summary.totalPlays.toLocaleString(),
+      suffix: "30s+",
+      detail: `${summary.totalEvents.toLocaleString()} listening events`,
+      icon: Play,
+    },
+    {
+      label: "Different tracks",
+      value: summary.uniqueTracks.toLocaleString(),
+      suffix: "tracks",
+      detail: `${summary.activeDays.toLocaleString()} active days`,
+      icon: Disc3,
+    },
+    {
+      label: "Artist universe",
+      value: summary.uniqueArtists.toLocaleString(),
+      suffix: "artists",
+      detail: `${summary.longestStreak} day longest streak`,
+      icon: Mic2,
+    },
+  ]
+
+  const behaviorCards = [
+    { label: "Skip rate", value: behavior.skipRate, icon: SkipForward },
+    { label: "Shuffle on", value: behavior.shuffleRate, icon: Shuffle },
+    { label: "Offline", value: behavior.offlineRate, icon: WifiOff },
+    { label: "Ended naturally", value: behavior.trackDoneRate, icon: CheckCircle2 },
+  ]
+
+  return (
+    <div id="spotify-dashboard" className="scroll-mt-28 space-y-8 pb-20">
+      <section className="flex flex-col justify-between gap-5 border-b border-white/10 pb-8 lg:flex-row lg:items-end">
+        <div>
+          <div className="mb-3 flex flex-wrap items-center gap-2">
+            <span className="inline-flex items-center gap-2 rounded-full border border-[#1DB954]/25 bg-[#1DB954]/10 px-3 py-1 text-xs font-medium text-[#4ade80]">
+              <Database className="h-3.5 w-3.5" aria-hidden="true" />
+              {sourceLabel}
+            </span>
+            <span className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1 text-xs text-zinc-400">
+              {source.recognizedFiles} {source.recognizedFiles === 1 ? "file" : "files"} analyzed
+            </span>
+          </div>
+          <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">Your listening, in full view</h2>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-zinc-400">
+            {formatDate(summary.firstPlayedAt)} – {formatDate(summary.lastPlayedAt)} · Times are displayed in this browser&apos;s local timezone.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          className="w-full border-white/15 bg-white/[0.04] text-white hover:bg-white/10 hover:text-white sm:w-auto"
+          onClick={onReset}
+        >
+          <RotateCcw className="mr-2 h-4 w-4" aria-hidden="true" />
+          Analyze different files
+        </Button>
+      </section>
+
+      <section aria-label="Listening summary" className="grid grid-cols-2 gap-3 lg:grid-cols-4 lg:gap-4">
+        {statCards.map((stat) => {
+          const Icon = stat.icon
+          return (
+            <Card key={stat.label} className="overflow-hidden border-white/10 bg-white/[0.04] text-white">
+              <CardContent className="p-4 sm:p-5">
+                <div className="flex items-start justify-between gap-3">
+                  <p className="text-xs font-medium uppercase tracking-[0.14em] text-zinc-500">{stat.label}</p>
+                  <Icon className="hidden h-4 w-4 shrink-0 text-[#4ade80] sm:block" aria-hidden="true" />
+                </div>
+                <div className="mt-4 flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                  <strong className="text-2xl font-bold tracking-tight text-white sm:text-3xl">{stat.value}</strong>
+                  <span className="text-xs text-[#4ade80]">{stat.suffix}</span>
+                </div>
+                <p className="mt-2 text-xs leading-5 text-zinc-500">{stat.detail}</p>
+              </CardContent>
+            </Card>
+          )
+        })}
+      </section>
+
+      <section aria-labelledby="listening-story-title">
+        <div className="mb-4 flex items-center gap-2">
+          <Sparkles className="h-4 w-4 text-[#4ade80]" aria-hidden="true" />
+          <h2 id="listening-story-title" className="text-sm font-semibold uppercase tracking-[0.16em] text-zinc-300">
+            Your listening story
+          </h2>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {analysis.insights.map((insight) => (
+            <article key={insight.eyebrow} className={`rounded-2xl border p-5 ${insightToneClasses[insight.tone]}`}>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.16em] opacity-70">{insight.eyebrow}</p>
+              <h3 className="mt-4 text-lg font-semibold leading-snug text-white">{insight.title}</h3>
+              <p className="mt-2 text-sm leading-6 text-zinc-300">{insight.body}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-3">
+        <ChartCard
+          className="lg:col-span-2"
+          title="Listening over time"
+          description="Total listening hours by month, including short listening events."
+        >
+          <div className="h-[310px] w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart data={analysis.monthly} margin={{ top: 12, right: 8, left: -22, bottom: 0 }}>
+                <defs>
+                  <linearGradient id="spotifyMonthlyArea" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="#1DB954" stopOpacity={0.45} />
+                    <stop offset="100%" stopColor="#1DB954" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid stroke="rgba(255,255,255,0.07)" strokeDasharray="3 3" vertical={false} />
+                <XAxis
+                  dataKey="month"
+                  axisLine={false}
+                  tickLine={false}
+                  interval={monthTickInterval}
+                  tickFormatter={formatMonth}
+                  tick={{ fill: "#71717a", fontSize: 11 }}
+                />
+                <YAxis
+                  axisLine={false}
+                  tickLine={false}
+                  tick={{ fill: "#71717a", fontSize: 11 }}
+                  tickFormatter={(value) => `${formatNumber(Number(value), 0)}h`}
+                />
+                <Tooltip content={<MonthlyTooltip />} />
+                <Area
+                  type="monotone"
+                  dataKey="hours"
+                  stroke="#1DB954"
+                  strokeWidth={2.5}
+                  fill="url(#spotifyMonthlyArea)"
+                  activeDot={{ r: 5, fill: "#4ade80", stroke: "#09090b", strokeWidth: 2 }}
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          </div>
+        </ChartCard>
+
+        <ChartCard
+          title="The years in music"
+          description="A year-by-year view of time, qualified plays, and artist breadth."
+        >
+          <div className="max-h-[310px] space-y-2 overflow-auto pr-1">
+            {[...analysis.yearly].reverse().map((year) => (
+              <div key={year.year} className="rounded-xl border border-white/[0.07] bg-black/10 p-3">
+                <div className="flex items-center justify-between gap-3">
+                  <strong className="text-lg text-white">{year.year}</strong>
+                  <span className="text-sm font-semibold text-[#4ade80]">{formatHours(year.hours)}</span>
+                </div>
+                <p className="mt-1 text-xs text-zinc-500">
+                  {year.plays.toLocaleString()} plays · {year.uniqueArtists.toLocaleString()} artists
+                </p>
+              </div>
+            ))}
+          </div>
+        </ChartCard>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <ChartCard
+          title="Your listening clock"
+          description="Total minutes by hour of day, converted to your current browser timezone."
+        >
+          <div className="h-[280px] w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={analysis.hourly} margin={{ top: 12, right: 8, left: -25, bottom: 0 }}>
+                <CartesianGrid stroke="rgba(255,255,255,0.07)" strokeDasharray="3 3" vertical={false} />
+                <XAxis
+                  dataKey="hour"
+                  axisLine={false}
+                  tickLine={false}
+                  interval={2}
+                  tickFormatter={(hour) => `${String(hour).padStart(2, "0")}:00`}
+                  tick={{ fill: "#71717a", fontSize: 10 }}
+                />
+                <YAxis axisLine={false} tickLine={false} tick={{ fill: "#71717a", fontSize: 11 }} />
+                <Tooltip
+                  content={(
+                    <RhythmTooltip
+                      unit="minutes"
+                      formatLabel={(hour: number) => `${String(hour).padStart(2, "0")}:00`}
+                    />
+                  )}
+                  cursor={{ fill: "rgba(255,255,255,0.04)" }}
+                />
+                <Bar dataKey="minutes" radius={[5, 5, 0, 0]}>
+                  {analysis.hourly.map((entry) => (
+                    <Cell
+                      key={entry.hour}
+                      fill={entry.hour >= 18 || entry.hour < 5 ? "#8b5cf6" : "#1DB954"}
+                      fillOpacity={0.85}
+                    />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </ChartCard>
+
+        <ChartCard
+          title="Your week in music"
+          description="Total listening minutes by weekday across the imported history."
+        >
+          <div className="h-[280px] w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={analysis.weekdays} margin={{ top: 12, right: 8, left: -25, bottom: 0 }}>
+                <CartesianGrid stroke="rgba(255,255,255,0.07)" strokeDasharray="3 3" vertical={false} />
+                <XAxis dataKey="shortDay" axisLine={false} tickLine={false} tick={{ fill: "#a1a1aa", fontSize: 11 }} />
+                <YAxis axisLine={false} tickLine={false} tick={{ fill: "#71717a", fontSize: 11 }} />
+                <Tooltip
+                  content={<RhythmTooltip unit="minutes" />}
+                  cursor={{ fill: "rgba(255,255,255,0.04)" }}
+                />
+                <Bar dataKey="minutes" fill="#1DB954" radius={[7, 7, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </ChartCard>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <ChartCard
+          title="Artists that stayed"
+          description="Ranked by total listening time, not raw event count."
+        >
+          <div className="space-y-2">
+            {analysis.topArtists.map((artist, index) => (
+              <RankingRow
+                key={artist.name}
+                rank={index + 1}
+                title={artist.name}
+                subtitle={`${artist.plays.toLocaleString()} qualified plays · ${artist.uniqueTracks.toLocaleString()} tracks`}
+                value={formatHours(artist.hours)}
+                percentage={(artist.hours / maxArtistHours) * 100}
+              />
+            ))}
+          </div>
+        </ChartCard>
+
+        <ChartCard
+          title="Tracks on repeat"
+          description="Ranked by qualified plays of 30 seconds or longer."
+        >
+          <div className="space-y-2">
+            {analysis.topTracks.map((track, index) => (
+              <RankingRow
+                key={`${track.artist}-${track.name}`}
+                rank={index + 1}
+                title={track.name}
+                subtitle={`${track.artist}${track.album ? ` · ${track.album}` : ""} · ${formatHours(track.hours)}`}
+                value={`${track.plays.toLocaleString()} plays`}
+                percentage={(track.plays / maxTrackPlays) * 100}
+              />
+            ))}
+          </div>
+        </ChartCard>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-3">
+        <ChartCard
+          className="lg:col-span-2"
+          title="How you press play"
+          description={behavior.hasExtendedData
+            ? "Behavior fields from Extended Streaming History. These describe playback events, not your personality."
+            : "These fields are not included in standard Spotify account history."
+          }
+        >
+          {behavior.hasExtendedData ? (
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              {behaviorCards.map((item) => {
+                const Icon = item.icon
+                return (
+                  <div key={item.label} className="rounded-2xl border border-white/[0.07] bg-black/10 p-4">
+                    <Icon className="h-4 w-4 text-[#4ade80]" aria-hidden="true" />
+                    <p className="mt-4 text-2xl font-bold text-white">
+                      {formatPercentage(item.value)}
+                    </p>
+                    <p className="mt-1 text-xs text-zinc-500">{item.label}</p>
+                  </div>
+                )
+              })}
+            </div>
+          ) : (
+            <div className="flex items-start gap-3 rounded-2xl border border-amber-300/15 bg-amber-300/[0.06] p-4 text-sm leading-6 text-amber-100">
+              <Info className="mt-1 h-4 w-4 shrink-0" aria-hidden="true" />
+              Upload Extended Streaming History to unlock skip, shuffle, offline, platform, album, and playback-reason insights.
+            </div>
+          )}
+        </ChartCard>
+
+        <ChartCard
+          title="Listening surfaces"
+          description="Top platforms by listening time in your extended export."
+        >
+          {analysis.platforms.length > 0 ? (
+            <div className="space-y-4">
+              {analysis.platforms.map((platform, index) => (
+                <div key={platform.name}>
+                  <div className="flex items-center justify-between gap-3 text-sm">
+                    <span className="flex min-w-0 items-center gap-2 text-zinc-300">
+                      {index === 0 ? <Radio className="h-3.5 w-3.5 shrink-0 text-[#4ade80]" /> : null}
+                      <span className="truncate" title={platform.name}>{platform.name}</span>
+                    </span>
+                    <span className="shrink-0 text-zinc-500">{platform.share}%</span>
+                  </div>
+                  <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-white/10">
+                    <div className="h-full rounded-full bg-[#1DB954]" style={{ width: `${platform.share}%` }} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="flex h-36 flex-col items-center justify-center text-center text-sm text-zinc-500">
+              <ListMusic className="mb-3 h-5 w-5" aria-hidden="true" />
+              Platform data is unavailable in this export.
+            </div>
+          )}
+        </ChartCard>
+      </section>
+
+      <section className="grid gap-3 rounded-2xl border border-white/10 bg-white/[0.025] p-5 text-sm text-zinc-400 sm:grid-cols-3">
+        <div className="flex items-start gap-3">
+          <CalendarDays className="mt-0.5 h-4 w-4 shrink-0 text-[#4ade80]" aria-hidden="true" />
+          <p>
+            Your biggest day was <strong className="font-medium text-zinc-200">{analysis.peakDay.date}</strong> with {formatHours(analysis.peakDay.hours)}.
+          </p>
+        </div>
+        <div className="flex items-start gap-3">
+          <Clock3 className="mt-0.5 h-4 w-4 shrink-0 text-[#4ade80]" aria-hidden="true" />
+          <p>
+            You average <strong className="font-medium text-zinc-200">{formatNumber(summary.averageMinutesPerActiveDay)} minutes</strong> per active listening day.
+          </p>
+        </div>
+        <div className="flex items-start gap-3">
+          <Database className="mt-0.5 h-4 w-4 shrink-0 text-[#4ade80]" aria-hidden="true" />
+          <p>
+            {source.duplicateRecordsOmitted + source.overlapRecordsOmitted > 0
+              ? `${(source.duplicateRecordsOmitted + source.overlapRecordsOmitted).toLocaleString()} duplicate or overlapping records were omitted.`
+              : "No duplicate or overlapping records needed to be removed."}
+          </p>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/components/spotify/spotify-upload.tsx
+++ b/components/spotify/spotify-upload.tsx
@@ -1,0 +1,351 @@
+"use client"
+
+import type React from "react"
+
+import { useRef, useState } from "react"
+import {
+  AlertCircle,
+  CheckCircle2,
+  FileJson,
+  Files,
+  FolderOpen,
+  Loader2,
+  ShieldCheck,
+  UploadCloud,
+  X,
+} from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import {
+  analyzeSpotifyStreams,
+  mergeSpotifyStreams,
+  parseSpotifyExport,
+  type SpotifyAnalysis,
+  type SpotifyStream,
+} from "@/lib/spotify-analysis"
+
+interface SpotifyUploadProps {
+  onComplete: (analysis: SpotifyAnalysis) => void
+}
+
+interface SelectedFiles {
+  files: File[]
+  ignoredCount: number
+}
+
+type DirectoryInputProps = React.InputHTMLAttributes<HTMLInputElement> & {
+  directory?: string
+  webkitdirectory?: string
+}
+
+const directoryInputProps: DirectoryInputProps = {
+  directory: "",
+  webkitdirectory: "",
+}
+
+const MAX_TOTAL_BYTES = 250 * 1024 * 1024
+const STREAMING_FILE_PATTERN = /(streaming[_-]?history[_-]?(audio|music)|endsong)/i
+
+function selectStreamingFiles(fileList: FileList | File[]): SelectedFiles {
+  const allFiles = Array.from(fileList)
+  const jsonFiles = allFiles.filter((file) => file.name.toLocaleLowerCase().endsWith(".json"))
+  const likelyStreamingFiles = jsonFiles.filter((file) =>
+    STREAMING_FILE_PATTERN.test(file.webkitRelativePath || file.name),
+  )
+  const candidates = likelyStreamingFiles.length > 0 ? likelyStreamingFiles : jsonFiles
+  const seenFiles = new Set<string>()
+  const files = candidates.filter((file) => {
+    const identity = [file.webkitRelativePath || file.name, file.size, file.lastModified].join("|")
+    if (seenFiles.has(identity)) return false
+    seenFiles.add(identity)
+    return true
+  })
+
+  return {
+    files,
+    ignoredCount: allFiles.length - files.length,
+  }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024 * 1024) return `${Math.max(1, Math.round(bytes / 1024))} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+}
+
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => window.requestAnimationFrame(() => resolve()))
+}
+
+export default function SpotifyUpload({ onComplete }: SpotifyUploadProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const directoryInputRef = useRef<HTMLInputElement>(null)
+  const [selection, setSelection] = useState<SelectedFiles>({ files: [], ignoredCount: 0 })
+  const [isDragging, setIsDragging] = useState(false)
+  const [isProcessing, setIsProcessing] = useState(false)
+  const [progress, setProgress] = useState(0)
+  const [stage, setStage] = useState("")
+  const [error, setError] = useState<string | null>(null)
+
+  const setFiles = (files: FileList | File[]) => {
+    const nextSelection = selectStreamingFiles(files)
+    setError(null)
+
+    if (nextSelection.files.length === 0) {
+      setSelection({ files: [], ignoredCount: 0 })
+      setError("No JSON files were found. Choose your unzipped Spotify Account Data folder or its streaming-history JSON files.")
+      return
+    }
+
+    const totalBytes = nextSelection.files.reduce((sum, file) => sum + file.size, 0)
+    if (totalBytes > MAX_TOTAL_BYTES) {
+      setSelection({ files: [], ignoredCount: 0 })
+      setError("The selected streaming-history files exceed the 250 MB local processing limit.")
+      return
+    }
+
+    setSelection(nextSelection)
+  }
+
+  const clearSelection = () => {
+    setSelection({ files: [], ignoredCount: 0 })
+    setError(null)
+    setProgress(0)
+    setStage("")
+    if (fileInputRef.current) fileInputRef.current.value = ""
+    if (directoryInputRef.current) directoryInputRef.current.value = ""
+  }
+
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    setIsDragging(false)
+    if (event.dataTransfer.files.length > 0) setFiles(event.dataTransfer.files)
+  }
+
+  const processFiles = async () => {
+    if (selection.files.length === 0) return
+
+    setIsProcessing(true)
+    setError(null)
+    setProgress(3)
+    const extended: SpotifyStream[] = []
+    const standard: SpotifyStream[] = []
+    let recognizedFiles = 0
+    let ignoredFiles = selection.ignoredCount
+
+    try {
+      for (let index = 0; index < selection.files.length; index += 1) {
+        const file = selection.files[index]
+        setStage(`Reading ${file.name}`)
+        setProgress(Math.round(5 + (index / selection.files.length) * 72))
+        await nextFrame()
+
+        try {
+          const data: unknown = JSON.parse(await file.text())
+          const parsed = parseSpotifyExport(data)
+          if (parsed.extended.length + parsed.standard.length === 0) {
+            ignoredFiles += 1
+          } else {
+            recognizedFiles += 1
+            extended.push(...parsed.extended)
+            standard.push(...parsed.standard)
+          }
+        } catch {
+          ignoredFiles += 1
+        }
+      }
+
+      if (extended.length + standard.length === 0) {
+        throw new Error(
+          "No music streaming history was found. Spotify Technical Log Information is not a listening-history export; choose Spotify Account Data instead.",
+        )
+      }
+
+      setProgress(82)
+      setStage("Removing overlap and duplicate records")
+      await nextFrame()
+      const merged = mergeSpotifyStreams(extended, standard, { recognizedFiles, ignoredFiles })
+
+      setProgress(91)
+      setStage("Building your listening story")
+      await nextFrame()
+      const analysis = analyzeSpotifyStreams(merged)
+
+      setProgress(100)
+      setStage("Your dashboard is ready")
+      await nextFrame()
+      onComplete(analysis)
+    } catch (processingError) {
+      const message = processingError instanceof Error
+        ? processingError.message
+        : "We could not analyze those files. Check that they are unmodified Spotify JSON exports."
+      setError(message)
+    } finally {
+      setIsProcessing(false)
+    }
+  }
+
+  const totalBytes = selection.files.reduce((sum, file) => sum + file.size, 0)
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <div
+          role="alert"
+          className="flex items-start gap-3 rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-800"
+        >
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+          <p>{error}</p>
+        </div>
+      )}
+
+      {selection.files.length === 0 ? (
+        <div
+          className={`rounded-3xl border border-dashed p-6 transition-all sm:p-8 ${
+            isDragging
+              ? "scale-[1.01] border-[#1DB954] bg-[#1DB954]/10"
+              : "border-white/15 bg-white/[0.04] hover:border-white/25 hover:bg-white/[0.06]"
+          }`}
+          onDragEnter={(event) => {
+            event.preventDefault()
+            setIsDragging(true)
+          }}
+          onDragOver={(event) => event.preventDefault()}
+          onDragLeave={(event) => {
+            if (!event.currentTarget.contains(event.relatedTarget as Node)) setIsDragging(false)
+          }}
+          onDrop={handleDrop}
+        >
+          <div className="mx-auto flex max-w-md flex-col items-center text-center">
+            <div className="mb-5 flex h-16 w-16 items-center justify-center rounded-2xl bg-[#1DB954]/15 text-[#4ade80] ring-1 ring-inset ring-[#1DB954]/25">
+              <UploadCloud className="h-8 w-8" aria-hidden="true" />
+            </div>
+            <h2 className="text-xl font-semibold text-white">Bring your Spotify history</h2>
+            <p className="mt-2 text-sm leading-6 text-zinc-400">
+              Drop one or more JSON files here, or choose the complete unzipped export folder.
+            </p>
+
+            <div className="mt-6 flex w-full flex-col gap-3 sm:flex-row">
+              <Button
+                type="button"
+                className="h-11 flex-1 bg-[#1DB954] font-semibold text-zinc-950 hover:bg-[#1ed760]"
+                onClick={() => fileInputRef.current?.click()}
+              >
+                <Files className="mr-2 h-4 w-4" aria-hidden="true" />
+                Choose JSON files
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                className="h-11 flex-1 border-white/15 bg-white/[0.04] text-white hover:bg-white/10 hover:text-white"
+                onClick={() => directoryInputRef.current?.click()}
+              >
+                <FolderOpen className="mr-2 h-4 w-4" aria-hidden="true" />
+                Choose export folder
+              </Button>
+            </div>
+
+            <input
+              ref={fileInputRef}
+              className="hidden"
+              type="file"
+              accept=".json,application/json"
+              multiple
+              onChange={(event) => event.target.files && setFiles(event.target.files)}
+            />
+            <input
+              ref={directoryInputRef}
+              className="hidden"
+              type="file"
+              multiple
+              {...directoryInputProps}
+              onChange={(event) => event.target.files && setFiles(event.target.files)}
+            />
+
+            <div className="mt-5 flex items-center gap-2 text-xs text-zinc-500">
+              <ShieldCheck className="h-3.5 w-3.5 text-[#4ade80]" aria-hidden="true" />
+              Files stay in this browser tab and are never uploaded
+            </div>
+          </div>
+        </div>
+      ) : (
+        <Card className="border-white/10 bg-zinc-900/80 text-white shadow-2xl shadow-black/20">
+          <CardContent className="p-5 sm:p-6">
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex min-w-0 items-start gap-3">
+                <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-[#1DB954]/15 text-[#4ade80]">
+                  <FileJson className="h-5 w-5" aria-hidden="true" />
+                </div>
+                <div className="min-w-0">
+                  <p className="font-semibold">
+                    {selection.files.length} streaming {selection.files.length === 1 ? "file" : "files"}
+                  </p>
+                  <p className="mt-1 text-sm text-zinc-400">
+                    {formatBytes(totalBytes)} selected
+                    {selection.ignoredCount > 0 ? ` · ${selection.ignoredCount} other or duplicate files skipped` : ""}
+                  </p>
+                </div>
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                disabled={isProcessing}
+                className="shrink-0 rounded-full text-zinc-400 hover:bg-white/10 hover:text-white"
+                onClick={clearSelection}
+              >
+                <X className="h-4 w-4" aria-hidden="true" />
+                <span className="sr-only">Clear selected files</span>
+              </Button>
+            </div>
+
+            <div className="mt-4 max-h-32 space-y-1 overflow-auto rounded-xl border border-white/10 bg-black/20 p-3 text-xs text-zinc-400">
+              {selection.files.slice(0, 8).map((file) => (
+                <div key={`${file.webkitRelativePath}-${file.name}-${file.size}`} className="flex items-center justify-between gap-4">
+                  <span className="truncate">{file.webkitRelativePath || file.name}</span>
+                  <span className="shrink-0 font-mono text-zinc-500">{formatBytes(file.size)}</span>
+                </div>
+              ))}
+              {selection.files.length > 8 && <p>+ {selection.files.length - 8} more files</p>}
+            </div>
+
+            {isProcessing ? (
+              <div className="mt-5 space-y-3" aria-live="polite">
+                <div className="h-2 overflow-hidden rounded-full bg-white/10">
+                  <div
+                    className="h-full rounded-full bg-gradient-to-r from-[#1DB954] to-emerald-300 transition-[width] duration-300"
+                    style={{ width: `${progress}%` }}
+                  />
+                </div>
+                <div className="flex items-center justify-between gap-4 text-sm">
+                  <span className="flex min-w-0 items-center gap-2 text-zinc-400">
+                    {progress === 100 ? (
+                      <CheckCircle2 className="h-4 w-4 shrink-0 text-[#4ade80]" />
+                    ) : (
+                      <Loader2 className="h-4 w-4 shrink-0 animate-spin text-[#4ade80]" />
+                    )}
+                    <span className="truncate">{stage}</span>
+                  </span>
+                  <span className="shrink-0 font-mono text-[#4ade80]">{progress}%</span>
+                </div>
+              </div>
+            ) : (
+              <Button
+                type="button"
+                className="mt-5 h-12 w-full bg-[#1DB954] text-base font-semibold text-zinc-950 hover:bg-[#1ed760]"
+                onClick={processFiles}
+              >
+                Analyze my listening history
+              </Button>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      <p className="text-center text-xs leading-5 text-zinc-500">
+        Best results: <strong className="font-medium text-zinc-400">Streaming_History_Audio_*.json</strong> from
+        Extended Streaming History. Standard <strong className="font-medium text-zinc-400">StreamingHistory_music_*.json</strong> files also work.
+      </p>
+    </div>
+  )
+}

--- a/lib/spotify-analysis.ts
+++ b/lib/spotify-analysis.ts
@@ -1,0 +1,590 @@
+export type SpotifySourceFormat = "extended" | "standard" | "mixed"
+
+export interface SpotifyStream {
+  timestamp: number
+  msPlayed: number
+  artist: string
+  track: string
+  album?: string
+  trackUri?: string
+  platform?: string
+  reasonEnd?: string
+  shuffle?: boolean
+  skipped?: boolean
+  offline?: boolean
+  source: Exclude<SpotifySourceFormat, "mixed">
+}
+
+export interface ParsedSpotifyExport {
+  extended: SpotifyStream[]
+  standard: SpotifyStream[]
+}
+
+export interface SpotifySourceSummary {
+  format: SpotifySourceFormat
+  recognizedFiles: number
+  ignoredFiles: number
+  inputRecords: number
+  retainedRecords: number
+  extendedRecords: number
+  standardRecords: number
+  duplicateRecordsOmitted: number
+  overlapRecordsOmitted: number
+}
+
+export interface SpotifyRankedArtist {
+  name: string
+  hours: number
+  plays: number
+  uniqueTracks: number
+  share: number
+}
+
+export interface SpotifyRankedTrack {
+  name: string
+  artist: string
+  album?: string
+  hours: number
+  plays: number
+}
+
+export interface SpotifyInsight {
+  eyebrow: string
+  title: string
+  body: string
+  tone: "green" | "violet" | "amber" | "sky"
+}
+
+export interface SpotifyAnalysis {
+  source: SpotifySourceSummary
+  summary: {
+    totalHours: number
+    totalPlays: number
+    totalEvents: number
+    uniqueTracks: number
+    uniqueArtists: number
+    activeDays: number
+    spanDays: number
+    averageMinutesPerActiveDay: number
+    longestStreak: number
+    firstPlayedAt: number
+    lastPlayedAt: number
+  }
+  monthly: { month: string; hours: number; plays: number }[]
+  hourly: { hour: number; minutes: number; plays: number }[]
+  weekdays: { day: string; shortDay: string; minutes: number; plays: number }[]
+  yearly: { year: string; hours: number; plays: number; uniqueArtists: number }[]
+  topArtists: SpotifyRankedArtist[]
+  topTracks: SpotifyRankedTrack[]
+  platforms: { name: string; hours: number; share: number }[]
+  behavior: {
+    hasExtendedData: boolean
+    skipRate?: number
+    shuffleRate?: number
+    offlineRate?: number
+    trackDoneRate?: number
+  }
+  peakDay: { date: string; hours: number; plays: number }
+  insights: SpotifyInsight[]
+}
+
+interface MergeSpotifyOptions {
+  recognizedFiles: number
+  ignoredFiles: number
+}
+
+interface MergedSpotifyStreams {
+  streams: SpotifyStream[]
+  source: SpotifySourceSummary
+}
+
+const MIN_PLAY_MS = 30_000
+const HOUR_MS = 60 * 60 * 1000
+const DAY_MS = 24 * HOUR_MS
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}
+
+function stringValue(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined
+  const normalized = value.trim()
+  return normalized || undefined
+}
+
+function booleanValue(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined
+}
+
+function numberValue(value: unknown): number | undefined {
+  if (typeof value !== "number" && typeof value !== "string") return undefined
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+function parseTimestamp(value: unknown): number | undefined {
+  if (typeof value !== "string") return undefined
+
+  // Spotify's standard export omits a timezone and uses a space separator.
+  const normalized = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/.test(value)
+    ? `${value.replace(" ", "T")}:00Z`
+    : value
+  const timestamp = new Date(normalized).getTime()
+  return Number.isFinite(timestamp) ? timestamp : undefined
+}
+
+function normalizeExtendedRecord(record: Record<string, unknown>): SpotifyStream | null {
+  if (!("ts" in record) || !("ms_played" in record)) return null
+
+  const timestamp = parseTimestamp(record.ts)
+  const msPlayed = numberValue(record.ms_played)
+  const artist = stringValue(record.master_metadata_album_artist_name)
+  const track = stringValue(record.master_metadata_track_name)
+
+  // Podcast episodes and audiobook chapters share the extended export schema.
+  // The music analyzer intentionally keeps only records with track metadata.
+  if (timestamp === undefined || msPlayed === undefined || !artist || !track) return null
+
+  return {
+    timestamp,
+    msPlayed: Math.max(0, msPlayed),
+    artist,
+    track,
+    album: stringValue(record.master_metadata_album_album_name),
+    trackUri: stringValue(record.spotify_track_uri),
+    platform: stringValue(record.platform),
+    reasonEnd: stringValue(record.reason_end),
+    shuffle: booleanValue(record.shuffle),
+    skipped: booleanValue(record.skipped),
+    offline: booleanValue(record.offline),
+    source: "extended",
+  }
+}
+
+function normalizeStandardRecord(record: Record<string, unknown>): SpotifyStream | null {
+  if (!("endTime" in record) || !("msPlayed" in record)) return null
+
+  const timestamp = parseTimestamp(record.endTime)
+  const msPlayed = numberValue(record.msPlayed)
+  const artist = stringValue(record.artistName)
+  const track = stringValue(record.trackName)
+  if (timestamp === undefined || msPlayed === undefined || !artist || !track) return null
+
+  return {
+    timestamp,
+    msPlayed: Math.max(0, msPlayed),
+    artist,
+    track,
+    source: "standard",
+  }
+}
+
+export function parseSpotifyExport(data: unknown): ParsedSpotifyExport {
+  const records = Array.isArray(data)
+    ? data
+    : isRecord(data) && Array.isArray(data.items)
+      ? data.items
+      : []
+
+  const extended: SpotifyStream[] = []
+  const standard: SpotifyStream[] = []
+
+  records.forEach((value) => {
+    if (!isRecord(value)) return
+
+    const extendedStream = normalizeExtendedRecord(value)
+    if (extendedStream) {
+      extended.push(extendedStream)
+      return
+    }
+
+    const standardStream = normalizeStandardRecord(value)
+    if (standardStream) standard.push(standardStream)
+  })
+
+  return { extended, standard }
+}
+
+export function mergeSpotifyStreams(
+  extendedInput: SpotifyStream[],
+  standardInput: SpotifyStream[],
+  options: MergeSpotifyOptions,
+): MergedSpotifyStreams {
+  let retainedStandard = standardInput
+  let overlapRecordsOmitted = 0
+
+  // The standard export normally overlaps the complete extended export. Keep
+  // standard records only when they extend beyond the imported extended range.
+  if (extendedInput.length > 0 && retainedStandard.length > 0) {
+    const { firstExtended, lastExtended } = extendedInput.reduce(
+      (range, stream) => ({
+        firstExtended: Math.min(range.firstExtended, stream.timestamp),
+        lastExtended: Math.max(range.lastExtended, stream.timestamp),
+      }),
+      { firstExtended: Number.POSITIVE_INFINITY, lastExtended: Number.NEGATIVE_INFINITY },
+    )
+    retainedStandard = standardInput.filter(
+      (stream) => stream.timestamp < firstExtended || stream.timestamp > lastExtended,
+    )
+    overlapRecordsOmitted = standardInput.length - retainedStandard.length
+  }
+
+  const streams = [...extendedInput, ...retainedStandard].sort(
+    (left, right) => left.timestamp - right.timestamp,
+  )
+  const format: SpotifySourceFormat =
+    extendedInput.length > 0 && retainedStandard.length > 0
+      ? "mixed"
+      : extendedInput.length > 0
+        ? "extended"
+        : "standard"
+
+  return {
+    streams,
+    source: {
+      format,
+      recognizedFiles: options.recognizedFiles,
+      ignoredFiles: options.ignoredFiles,
+      inputRecords: extendedInput.length + standardInput.length,
+      retainedRecords: streams.length,
+      extendedRecords: extendedInput.length,
+      standardRecords: retainedStandard.length,
+      duplicateRecordsOmitted: 0,
+      overlapRecordsOmitted,
+    },
+  }
+}
+
+function pad(value: number): string {
+  return String(value).padStart(2, "0")
+}
+
+function dateKey(timestamp: number): string {
+  const date = new Date(timestamp)
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+}
+
+function monthKey(timestamp: number): string {
+  const date = new Date(timestamp)
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}`
+}
+
+function dayNumber(key: string): number {
+  const [year, month, day] = key.split("-").map(Number)
+  return Date.UTC(year, month - 1, day) / DAY_MS
+}
+
+function round(value: number, digits = 1): number {
+  const multiplier = 10 ** digits
+  return Math.round(value * multiplier) / multiplier
+}
+
+function rate(numerator: number, denominator: number): number | undefined {
+  return denominator > 0 ? round((numerator / denominator) * 100, 2) : undefined
+}
+
+function calculateLongestStreak(keys: string[]): number {
+  const days = [...new Set(keys)].map(dayNumber).sort((left, right) => left - right)
+  if (days.length === 0) return 0
+
+  let longest = 1
+  let current = 1
+  for (let index = 1; index < days.length; index += 1) {
+    if (days[index] - days[index - 1] === 1) {
+      current += 1
+      longest = Math.max(longest, current)
+    } else {
+      current = 1
+    }
+  }
+  return longest
+}
+
+function fillMonthlySeries(
+  firstTimestamp: number,
+  lastTimestamp: number,
+  values: Map<string, { ms: number; plays: number }>,
+): SpotifyAnalysis["monthly"] {
+  const first = new Date(firstTimestamp)
+  const last = new Date(lastTimestamp)
+  const cursor = new Date(first.getFullYear(), first.getMonth(), 1)
+  const end = new Date(last.getFullYear(), last.getMonth(), 1)
+  const result: SpotifyAnalysis["monthly"] = []
+
+  while (cursor <= end) {
+    const key = `${cursor.getFullYear()}-${pad(cursor.getMonth() + 1)}`
+    const value = values.get(key) || { ms: 0, plays: 0 }
+    result.push({ month: key, hours: round(value.ms / HOUR_MS, 2), plays: value.plays })
+    cursor.setMonth(cursor.getMonth() + 1)
+  }
+
+  return result
+}
+
+export function analyzeSpotifyStreams(merged: MergedSpotifyStreams): SpotifyAnalysis {
+  const { streams, source } = merged
+  if (streams.length === 0) {
+    throw new Error("No Spotify music streaming records were found.")
+  }
+
+  const meaningfulStreams = streams.filter((stream) => stream.msPlayed >= MIN_PLAY_MS)
+  const totalMs = streams.reduce((sum, stream) => sum + stream.msPlayed, 0)
+  const firstPlayedAt = streams[0].timestamp
+  const lastPlayedAt = streams[streams.length - 1].timestamp
+
+  const monthlyMap = new Map<string, { ms: number; plays: number }>()
+  const dailyMap = new Map<string, { ms: number; plays: number }>()
+  const hourlyMap = Array.from({ length: 24 }, (_, hour) => ({ hour, ms: 0, plays: 0 }))
+  const weekdayMap = Array.from({ length: 7 }, () => ({ ms: 0, plays: 0 }))
+  const yearlyMap = new Map<string, { ms: number; plays: number; artists: Set<string> }>()
+  const artistMap = new Map<string, { displayName: string; ms: number; plays: number; tracks: Set<string> }>()
+  const trackMap = new Map<
+    string,
+    { name: string; artist: string; album?: string; ms: number; plays: number }
+  >()
+  const platformMap = new Map<string, number>()
+
+  streams.forEach((stream) => {
+    const isPlay = stream.msPlayed >= MIN_PLAY_MS
+    const month = monthKey(stream.timestamp)
+    const day = dateKey(stream.timestamp)
+    const date = new Date(stream.timestamp)
+    const year = String(date.getFullYear())
+
+    const monthEntry = monthlyMap.get(month) || { ms: 0, plays: 0 }
+    monthEntry.ms += stream.msPlayed
+    monthEntry.plays += Number(isPlay)
+    monthlyMap.set(month, monthEntry)
+
+    const dayEntry = dailyMap.get(day) || { ms: 0, plays: 0 }
+    dayEntry.ms += stream.msPlayed
+    dayEntry.plays += Number(isPlay)
+    dailyMap.set(day, dayEntry)
+
+    const hourEntry = hourlyMap[date.getHours()]
+    hourEntry.ms += stream.msPlayed
+    hourEntry.plays += Number(isPlay)
+
+    // Convert Sunday-first Date#getDay() to Monday-first data.
+    const weekdayIndex = (date.getDay() + 6) % 7
+    weekdayMap[weekdayIndex].ms += stream.msPlayed
+    weekdayMap[weekdayIndex].plays += Number(isPlay)
+
+    const yearEntry = yearlyMap.get(year) || { ms: 0, plays: 0, artists: new Set<string>() }
+    yearEntry.ms += stream.msPlayed
+    yearEntry.plays += Number(isPlay)
+    if (isPlay) yearEntry.artists.add(stream.artist)
+    yearlyMap.set(year, yearEntry)
+
+    const artistKey = stream.artist.toLocaleLowerCase()
+    const artistEntry = artistMap.get(artistKey) || {
+      displayName: stream.artist,
+      ms: 0,
+      plays: 0,
+      tracks: new Set<string>(),
+    }
+    artistEntry.ms += stream.msPlayed
+    artistEntry.plays += Number(isPlay)
+    if (isPlay) artistEntry.tracks.add(stream.track.toLocaleLowerCase())
+    artistMap.set(artistKey, artistEntry)
+
+    const trackKey = stream.trackUri || `${artistKey}::${stream.track.toLocaleLowerCase()}`
+    const trackEntry = trackMap.get(trackKey) || {
+      name: stream.track,
+      artist: stream.artist,
+      album: stream.album,
+      ms: 0,
+      plays: 0,
+    }
+    trackEntry.ms += stream.msPlayed
+    trackEntry.plays += Number(isPlay)
+    trackMap.set(trackKey, trackEntry)
+
+    if (stream.platform) {
+      platformMap.set(stream.platform, (platformMap.get(stream.platform) || 0) + stream.msPlayed)
+    }
+  })
+
+  const totalPlays = meaningfulStreams.length
+  const uniqueTracks = new Set(
+    streams.map(
+      (stream) => stream.trackUri || `${stream.artist.toLocaleLowerCase()}::${stream.track.toLocaleLowerCase()}`,
+    ),
+  ).size
+  const uniqueArtists = new Set(streams.map((stream) => stream.artist.toLocaleLowerCase())).size
+  const activeDayKeys = [...dailyMap.entries()]
+    .filter(([, value]) => value.ms > 0)
+    .map(([key]) => key)
+  const activeDays = activeDayKeys.length
+  const spanDays = Math.max(1, dayNumber(dateKey(lastPlayedAt)) - dayNumber(dateKey(firstPlayedAt)) + 1)
+
+  const topArtists = [...artistMap.values()]
+    .sort((left, right) => right.ms - left.ms)
+    .slice(0, 10)
+    .map((entry) => ({
+      name: entry.displayName,
+      hours: round(entry.ms / HOUR_MS, 1),
+      plays: entry.plays,
+      uniqueTracks: entry.tracks.size,
+      share: totalMs > 0 ? round((entry.ms / totalMs) * 100, 1) : 0,
+    }))
+
+  const topTracks = [...trackMap.values()]
+    .sort((left, right) => right.plays - left.plays || right.ms - left.ms)
+    .slice(0, 10)
+    .map((entry) => ({
+      name: entry.name,
+      artist: entry.artist,
+      album: entry.album,
+      hours: round(entry.ms / HOUR_MS, 1),
+      plays: entry.plays,
+    }))
+
+  const weekdays = [
+    ["Monday", "Mon"],
+    ["Tuesday", "Tue"],
+    ["Wednesday", "Wed"],
+    ["Thursday", "Thu"],
+    ["Friday", "Fri"],
+    ["Saturday", "Sat"],
+    ["Sunday", "Sun"],
+  ].map(([day, shortDay], index) => ({
+    day,
+    shortDay,
+    minutes: round(weekdayMap[index].ms / 60_000, 1),
+    plays: weekdayMap[index].plays,
+  }))
+
+  const yearly = [...yearlyMap.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([year, value]) => ({
+      year,
+      hours: round(value.ms / HOUR_MS, 1),
+      plays: value.plays,
+      uniqueArtists: value.artists.size,
+    }))
+
+  const platforms = [...platformMap.entries()]
+    .sort(([, left], [, right]) => right - left)
+    .slice(0, 5)
+    .map(([name, ms]) => ({
+      name,
+      hours: round(ms / HOUR_MS, 1),
+      share: totalMs > 0 ? round((ms / totalMs) * 100, 1) : 0,
+    }))
+
+  const peakDayEntry = [...dailyMap.entries()].reduce(
+    (peak, entry) => (entry[1].ms > peak[1].ms ? entry : peak),
+    ["", { ms: 0, plays: 0 }] as [string, { ms: number; plays: number }],
+  )
+
+  const extendedStreams = streams.filter((stream) => stream.source === "extended")
+  const skippedKnown = extendedStreams.filter((stream) => stream.skipped !== undefined)
+  const shuffleKnown = extendedStreams.filter((stream) => stream.shuffle !== undefined)
+  const offlineKnown = extendedStreams.filter((stream) => stream.offline !== undefined)
+  const reasonEndKnown = extendedStreams.filter((stream) => Boolean(stream.reasonEnd))
+  const behavior: SpotifyAnalysis["behavior"] = {
+    hasExtendedData: extendedStreams.length > 0,
+    skipRate: rate(skippedKnown.filter((stream) => stream.skipped).length, skippedKnown.length),
+    shuffleRate: rate(shuffleKnown.filter((stream) => stream.shuffle).length, shuffleKnown.length),
+    offlineRate: rate(offlineKnown.filter((stream) => stream.offline).length, offlineKnown.length),
+    trackDoneRate: rate(
+      reasonEndKnown.filter((stream) => stream.reasonEnd?.toLocaleLowerCase() === "trackdone").length,
+      reasonEndKnown.length,
+    ),
+  }
+
+  const timePeriods = [
+    { name: "late-night", label: "A late-night soundtrack", hours: [0, 1, 2, 3, 4] },
+    { name: "morning", label: "A morning soundtrack", hours: [5, 6, 7, 8, 9, 10, 11] },
+    { name: "afternoon", label: "An afternoon soundtrack", hours: [12, 13, 14, 15, 16, 17] },
+    { name: "evening", label: "An evening soundtrack", hours: [18, 19, 20, 21, 22, 23] },
+  ].map((period) => ({
+    ...period,
+    ms: period.hours.reduce((sum, hour) => sum + hourlyMap[hour].ms, 0),
+  }))
+  const dominantPeriod = timePeriods.reduce((best, current) => (current.ms > best.ms ? current : best))
+  const dominantShare = totalMs > 0 ? Math.round((dominantPeriod.ms / totalMs) * 100) : 0
+  const repeatRatio = totalPlays > 0 ? uniqueTracks / totalPlays : 0
+  const discoveryTitle = repeatRatio >= 0.55
+    ? "You keep the door open"
+    : repeatRatio <= 0.25
+      ? "You know what you love"
+      : "Familiar, with room to roam"
+  const discoveryBody = repeatRatio >= 0.55
+    ? `${Math.round(repeatRatio * 100)}% of your qualified plays map to a different track — a broad listening mix.`
+    : repeatRatio <= 0.25
+      ? `Your ${totalPlays.toLocaleString()} qualified plays circle back to ${uniqueTracks.toLocaleString()} tracks.`
+      : `You balance repeat favorites with discovery across ${uniqueTracks.toLocaleString()} tracks.`
+
+  const insights: SpotifyInsight[] = [
+    {
+      eyebrow: "Listening clock",
+      title: dominantPeriod.label,
+      body: `${dominantShare}% of your listening time lands in the ${dominantPeriod.name} window.`,
+      tone: "green",
+    },
+    {
+      eyebrow: "Artist gravity",
+      title: topArtists[0]?.name || "A wide-open rotation",
+      body: topArtists[0]
+        ? `${topArtists[0].share}% of your total listening time belongs to your top artist.`
+        : "No single artist dominates your listening history.",
+      tone: "violet",
+    },
+    {
+      eyebrow: "Discovery style",
+      title: discoveryTitle,
+      body: discoveryBody,
+      tone: "amber",
+    },
+    behavior.skipRate !== undefined
+      ? {
+          eyebrow: "Playback behavior",
+          title: behavior.skipRate < 20 ? "You let songs breathe" : "Your skip reflex is active",
+          body: `${round(behavior.skipRate, 1)}% of extended-history events are marked as skipped.`,
+          tone: "sky",
+        }
+      : {
+          eyebrow: "Listening cadence",
+          title: `${calculateLongestStreak(activeDayKeys)} days in a row`,
+          body: "That is your longest streak of days with recorded listening time.",
+          tone: "sky",
+        },
+  ]
+
+  return {
+    source,
+    summary: {
+      totalHours: round(totalMs / HOUR_MS, 1),
+      totalPlays,
+      totalEvents: streams.length,
+      uniqueTracks,
+      uniqueArtists,
+      activeDays,
+      spanDays,
+      averageMinutesPerActiveDay: activeDays > 0 ? round(totalMs / 60_000 / activeDays, 1) : 0,
+      longestStreak: calculateLongestStreak(activeDayKeys),
+      firstPlayedAt,
+      lastPlayedAt,
+    },
+    monthly: fillMonthlySeries(firstPlayedAt, lastPlayedAt, monthlyMap),
+    hourly: hourlyMap.map((entry) => ({
+      hour: entry.hour,
+      minutes: round(entry.ms / 60_000, 1),
+      plays: entry.plays,
+    })),
+    weekdays,
+    yearly,
+    topArtists,
+    topTracks,
+    platforms,
+    behavior,
+    peakDay: {
+      date: peakDayEntry[0],
+      hours: round(peakDayEntry[1].ms / HOUR_MS, 1),
+      plays: peakDayEntry[1].plays,
+    },
+    insights,
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "test": "node --test tests/*.test.mjs",
     "lint": "eslint ."
   },
   "dependencies": {

--- a/tests/content-semantics.test.mjs
+++ b/tests/content-semantics.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import test from "node:test"
+
+const youtubePage = readFileSync(new URL("../app/page.tsx", import.meta.url), "utf8")
+const spotifyPage = readFileSync(new URL("../app/spotify/page.tsx", import.meta.url), "utf8")
+const spotifyAnalyzer = readFileSync(
+  new URL("../components/spotify/spotify-analyzer.tsx", import.meta.url),
+  "utf8",
+)
+
+test("YouTube homepage does not present fabricated history as user data", () => {
+  assert.doesNotMatch(youtubePage, /Your viewing history/)
+  assert.doesNotMatch(youtubePage, /12,842|1,318|47 days/)
+  assert.match(youtubePage, /What this YouTube history analyzer measures/)
+  assert.match(youtubePage, /does not include dependable watch duration/)
+})
+
+test("Spotify page describes the input and calculations in visible content", () => {
+  assert.match(spotifyAnalyzer, /Analyze your/)
+  assert.match(spotifyAnalyzer, /Spotify listening history/)
+  assert.match(spotifyPage, /Standard Streaming History or Extended Streaming History/)
+  assert.match(spotifyPage, /separates total listening time from qualified plays/)
+})


### PR DESCRIPTION
## Summary

- add a browser-only Spotify history analyzer at `/spotify`
- support standard and extended Spotify listening-history exports
- add charts, rankings, playback insights, and responsive states
- unify Playback Stats navigation, visual styling, legal pages, and the YouTube dashboard shell
- align homepage title, description, and headings with established YouTube watch-history search intent
- keep the personal dashboard out of search results with `noindex`
- keep selected history files and generated insights on the user device

## User impact

Users can analyze YouTube or Spotify history from the same site while keeping platform-specific workflows and colors. The Spotify importer ignores technical logs and does not retain account, IP, location, or user-agent fields. The homepage remains focused on YouTube watch-history analysis.

## Validation

- `tsc --noEmit`
- `next build`
- ESLint: 0 errors
- desktop and 390px responsive browser checks
- real Spotify standard, extended, mixed-export, and technical-log samples
- privacy scan for local paths, credentials, exported records, and account identifiers